### PR TITLE
增加 assignable 类型白名单, ASSIGNABLE_ALLOWED_CLASS_SET 选项

### DIFF
--- a/src/main/java/com/googlecode/aviator/Options.java
+++ b/src/main/java/com/googlecode/aviator/Options.java
@@ -94,11 +94,21 @@ public enum Options {
 
   /**
    * Allowed java class set in new statement and class's static method(fields) etc. It's null by
-   * default, it means all classes are allowed. Empty set means forbidding all classes.
+   * default. Null ALLOWED_CLASS_SET and ASSIGNABLE_ALLOWED_CLASS_SET means all classes are allowed
+   * (default); Empty ALLOWED_CLASS_SET or ASSIGNABLE_ALLOWED_CLASS_SET means forbidding all
+   * classes.
    *
    * @since 5.2.2
    */
-  ALLOWED_CLASS_SET;
+  ALLOWED_CLASS_SET,
+
+  /**
+   * Allowed assignable java class set in new statement and class's static method(fields) etc. It's
+   * null by default. Null ALLOWED_CLASS_SET and ASSIGNABLE_ALLOWED_CLASS_SET means all classes are
+   * allowed (default); Empty ALLOWED_CLASS_SET or ASSIGNABLE_ALLOWED_CLASS_SET means forbidding all
+   * classes.
+   */
+  ASSIGNABLE_ALLOWED_CLASS_SET;
 
 
   /**
@@ -179,6 +189,7 @@ public enum Options {
       case MATH_CONTEXT:
         return val.mathContext;
       case ALLOWED_CLASS_SET:
+      case ASSIGNABLE_ALLOWED_CLASS_SET:
         return val.classes;
     }
     throw new IllegalArgumentException("Fail to cast value " + val + " for option " + this);
@@ -213,6 +224,7 @@ public enum Options {
       case MAX_LOOP_COUNT:
         return new Value(((Number) val).intValue());
       case ALLOWED_CLASS_SET:
+      case ASSIGNABLE_ALLOWED_CLASS_SET:
         return Value.fromClasses((Set<Class<?>>) val);
       case FEATURE_SET:
         return new Value((Set<Feature>) val);
@@ -235,6 +247,7 @@ public enum Options {
         return val instanceof Boolean;
       case FEATURE_SET:
       case ALLOWED_CLASS_SET:
+      case ASSIGNABLE_ALLOWED_CLASS_SET:
         return val instanceof Set;
       case OPTIMIZE_LEVEL:
         return val instanceof Integer && (((Integer) val).intValue() == AviatorEvaluator.EVAL
@@ -307,6 +320,7 @@ public enum Options {
       case FEATURE_SET:
         return FULL_FEATURE_SET;
       case ALLOWED_CLASS_SET:
+      case ASSIGNABLE_ALLOWED_CLASS_SET:
         return NULL_CLASS_SET;
     }
     return null;

--- a/src/main/java/com/googlecode/aviator/utils/Env.java
+++ b/src/main/java/com/googlecode/aviator/utils/Env.java
@@ -221,6 +221,17 @@ public class Env implements Map<String, Object> {
               "`" + clazz + "` is not in allowed class set, check Options.ALLOWED_CLASS_SET");
         }
       }
+      Set<Class<?>> assignableList =
+          this.instance.getOptionValue(Options.ASSIGNABLE_ALLOWED_CLASS_SET).classes;
+      if (assignableList != null) {
+        for (Class<?> aClass : assignableList) {
+          if (aClass.isAssignableFrom(clazz)) {
+            return clazz;
+          }
+        }
+        throw new ExpressionRuntimeException(
+            "`" + clazz + "` is not in allowed class set, check Options.ALLOWED_CLASS_SET");
+      }
     }
     return clazz;
   }

--- a/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceCompatibleUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceCompatibleUnitTest.java
@@ -30,6 +30,11 @@ public class AviatorEvaluatorInstanceCompatibleUnitTest extends AviatorEvaluator
   }
 
   @Override
+  public void testAssignableClazzWhiteList() {
+    // ignore
+  }
+
+  @Override
   @Test
   public void testDefaultOptionValues() {
     assertEquals(this.instance.getOption(Options.TRACE_EVAL), false);

--- a/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceUnitTest.java
@@ -84,6 +84,36 @@ public class AviatorEvaluatorInstanceUnitTest {
     this.instance.execute("try {} catch(IllegalArgumentException e) {}");
     assertTrue(this.instance
         .execute("new java.util.concurrent.ArrayBlockingQueue(10)") instanceof ArrayBlockingQueue);
+
+    // recover default value of option ALLOWED_CLASS_SET after test
+    this.instance.getOptionValue(Options.ALLOWED_CLASS_SET).classes = null;
+  }
+
+  @Test
+  public void testAssignableClazzWhiteList() {
+    final HashSet<Object> classes = new HashSet<>();
+    classes.add(List.class);
+    this.instance.setOption(Options.ASSIGNABLE_ALLOWED_CLASS_SET, classes);
+
+    try {
+      this.instance.execute("new java.util.Date()");
+      fail();
+    } catch (ExpressionRuntimeException e) {
+      assertEquals(
+          "`class java.util.Date` is not in allowed class set, check Options.ALLOWED_CLASS_SET",
+          e.getMessage());
+    }
+
+    List res = (List) this.instance.execute("l = new java.util.ArrayList();seq.add(l,1);l");
+    assertEquals(1, res.size());
+    assertEquals(Integer.valueOf(1), res.get(0));
+
+    List res2 = (List) this.instance.execute("l = new java.util.LinkedList();seq.add(l,1);l");
+    assertEquals(1, res2.size());
+    assertEquals(Integer.valueOf(1), res2.get(0));
+
+    // recover default value of option ALLOWED_CLASS_SET after test
+    this.instance.getOptionValue(Options.ASSIGNABLE_ALLOWED_CLASS_SET).classes = null;
   }
 
   @Test


### PR DESCRIPTION
to issue #351 

用户可以通过 ASSIGNABLE_ALLOWED_CLASS_SET 选项设置 assignable 类型白名单，举例如下：

```java
    final HashSet<Object> classes = new HashSet<>();
    classes.add(List.class);
    this.instance.setOption(Options.ASSIGNABLE_ALLOWED_CLASS_SET, classes);
```

之后就可以在脚本中调用所有 List 的子类，比如：

```
l = new java.util.ArrayList();
seq.add(l,1);
```