### PR TITLE
升级 junit 到 4.12，并且修复部分无效单测

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.3.1</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/googlecode/aviator/JavaMethodReflectionFunctionMissingTest.java
+++ b/src/test/java/com/googlecode/aviator/JavaMethodReflectionFunctionMissingTest.java
@@ -21,10 +21,10 @@ public class JavaMethodReflectionFunctionMissingTest {
 
   @Test
   public void testFunctionMissing() {
-    assertEquals(2, this.instance.execute("indexOf('hello','l')"));
+    assertEquals(2L, this.instance.execute("indexOf('hello','l')"));
     assertEquals("heeeo", this.instance.execute("replaceAll('hello','l','e')"));
     assertEquals("hello", this.instance.execute("trim(' hello ')"));
-    assertEquals(1, this.instance.execute("signum(3M)"));
+    assertEquals(1L, this.instance.execute("signum(3M)"));
     assertEquals("hello world",
         this.instance.execute("execute(__instance__, '\"hello\" + \" world\"')"));
     assertEquals(101L, this.instance.execute("execute(__instance__, '1+100')"));

--- a/src/test/java/com/googlecode/aviator/code/asm/ASMCodeGeneratorUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/code/asm/ASMCodeGeneratorUnitTest.java
@@ -383,7 +383,7 @@ public class ASMCodeGeneratorUnitTest {
     this.codeGenerator.onConstant(new NumberToken(-3L, "-3"));
     this.codeGenerator.onBitNot(null);
     Object result = eval(new HashMap<String, Object>());
-    assertEquals(2, result);
+    assertEquals(2L, result);
   }
 
   @Test
@@ -559,7 +559,7 @@ public class ASMCodeGeneratorUnitTest {
     env.put("y", 3);
     Object result = eval(env);
     assertTrue(result instanceof LambdaFunction);
-    assertEquals(5, ((LambdaFunction) result)
+    assertEquals(5L, ((LambdaFunction) result)
         .call(env, new AviatorJavaType("x"), new AviatorJavaType("y")).getValue(env));
     assertNull(this.codeGenerator.getLambdaGenerator());
   }

--- a/src/test/java/com/googlecode/aviator/example/VariableExample.java
+++ b/src/test/java/com/googlecode/aviator/example/VariableExample.java
@@ -37,8 +37,8 @@ public class VariableExample {
 
   public static class Foo {
 
-    int i;
-    float f;
+    long i;
+    double f;
     Date date = new Date();
     Bar[] bars = new Bar[1];
     Map<String, Object> context = new HashMap<String, Object>();
@@ -82,7 +82,7 @@ public class VariableExample {
     }
 
 
-    public int getI() {
+    public long getI() {
       return this.i;
     }
 
@@ -92,7 +92,7 @@ public class VariableExample {
     }
 
 
-    public float getF() {
+    public double getF() {
       return this.f;
     }
 

--- a/src/test/java/com/googlecode/aviator/lexer/ExpressionLexerUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/lexer/ExpressionLexerUnitTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import com.googlecode.aviator.lexer.token.NumberToken;
 import org.junit.Before;
 import org.junit.Test;
 import com.googlecode.aviator.AviatorEvaluator;
@@ -46,7 +47,7 @@ public class ExpressionLexerUnitTest {
     this.lexer = new ExpressionLexer(this.instance, "1+2");
     Token<?> token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(1, token.getValue(null));
+    assertEquals(1L, token.getValue(null));
     assertEquals(0, token.getStartIndex());
 
     token = this.lexer.scan();
@@ -56,7 +57,7 @@ public class ExpressionLexerUnitTest {
 
     token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(2, token.getValue(null));
+    assertEquals(2L, token.getValue(null));
     assertEquals(2, token.getStartIndex());
 
     assertNull(this.lexer.scan());
@@ -87,7 +88,7 @@ public class ExpressionLexerUnitTest {
     this.lexer = new ExpressionLexer(this.instance, "0X0a2B");
     Token<?> token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(2603, token.getValue(null));
+    assertEquals(2603L, token.getValue(null));
     assertEquals(0, token.getStartIndex());
   }
 
@@ -115,21 +116,21 @@ public class ExpressionLexerUnitTest {
   @Test
   public void testParseScientificNotationBiggerSmaller() {
     this.lexer = new ExpressionLexer(this.instance, "3e10");
-    Token<?> token = this.lexer.scan();
+    NumberToken token = (NumberToken) this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(3e10, token.getValue(null));
+    assertEquals(3e10, token.getValue(null).doubleValue(), 0.1);
     assertEquals(0, token.getStartIndex());
 
     this.lexer = new ExpressionLexer(this.instance, "3e100");
-    token = this.lexer.scan();
+    token = (NumberToken) this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(3e100, token.getValue(null));
+    assertEquals(3e100, token.getValue(null).doubleValue(), 1e86);
     assertEquals(0, token.getStartIndex());
 
     this.lexer = new ExpressionLexer(this.instance, "3e-100");
-    token = this.lexer.scan();
+    token = (NumberToken) this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(3e-100, token.getValue(null));
+    assertEquals(3e-100, token.getValue(null).doubleValue(), 1e-114);
     assertEquals(0, token.getStartIndex());
   }
 
@@ -169,7 +170,7 @@ public class ExpressionLexerUnitTest {
     this.lexer = new ExpressionLexer(this.instance, "3E2M");
     Token<?> token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(new BigDecimal("300"), token.getValue(null));
+    assertEquals(new BigDecimal("3E2"), token.getValue(null));
     assertEquals(0, token.getStartIndex());
   }
 
@@ -194,9 +195,9 @@ public class ExpressionLexerUnitTest {
   @Test
   public void testParseScientificNotation8() {
     this.lexer = new ExpressionLexer(this.instance, "2.3456e3");
-    Token<?> token = this.lexer.scan();
+    NumberToken token = (NumberToken) this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(2345.6, token.getValue(null));
+    assertEquals(2345.6, token.getValue(null).doubleValue(), 0.01);
     assertEquals(0, token.getStartIndex());
   }
 
@@ -235,7 +236,7 @@ public class ExpressionLexerUnitTest {
 
     token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(1, token.getValue(null));
+    assertEquals(1L, token.getValue(null));
     assertEquals(7, token.getStartIndex());
 
     token = this.lexer.scan();
@@ -286,7 +287,7 @@ public class ExpressionLexerUnitTest {
     this.lexer = new ExpressionLexer(this.instance, "0344");
     Token<?> token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(344, token.getValue(null));
+    assertEquals(344L, token.getValue(null));
     assertEquals(0, token.getStartIndex());
   }
 
@@ -296,7 +297,7 @@ public class ExpressionLexerUnitTest {
     this.lexer = new ExpressionLexer(this.instance, "3+0xAF");
     Token<?> token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(3, token.getValue(null));
+    assertEquals(3L, token.getValue(null));
     assertEquals(0, token.getStartIndex());
 
     token = this.lexer.scan();
@@ -306,7 +307,7 @@ public class ExpressionLexerUnitTest {
 
     token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(175, token.getValue(null));
+    assertEquals(175L, token.getValue(null));
     assertEquals(2, token.getStartIndex());
 
     assertNull(this.lexer.scan());
@@ -318,7 +319,7 @@ public class ExpressionLexerUnitTest {
     this.lexer = new ExpressionLexer(this.instance, " 1 + 2 ");
     Token<?> token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(1, token.getValue(null));
+    assertEquals(1L, token.getValue(null));
     assertEquals(1, token.getStartIndex());
 
     token = this.lexer.scan();
@@ -328,7 +329,7 @@ public class ExpressionLexerUnitTest {
 
     token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(2, token.getValue(null));
+    assertEquals(2L, token.getValue(null));
     assertEquals(5, token.getStartIndex());
 
     assertNull(this.lexer.scan());
@@ -350,7 +351,7 @@ public class ExpressionLexerUnitTest {
 
     token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(4, token.getValue(null));
+    assertEquals(4L, token.getValue(null));
     assertEquals(4, token.getStartIndex());
 
     token = this.lexer.scan();
@@ -477,7 +478,7 @@ public class ExpressionLexerUnitTest {
 
     token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(3, token.getValue(null));
+    assertEquals(3L, token.getValue(null));
 
     token = this.lexer.scan();
     assertEquals(TokenType.Char, token.getType());
@@ -489,7 +490,7 @@ public class ExpressionLexerUnitTest {
 
     token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(1, token.getValue(null));
+    assertEquals(1L, token.getValue(null));
 
     token = this.lexer.scan();
     assertEquals(TokenType.Char, token.getType());
@@ -549,7 +550,7 @@ public class ExpressionLexerUnitTest {
 
     token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(3, token.getValue(null));
+    assertEquals(3L, token.getValue(null));
 
     token = this.lexer.scan();
     assertEquals(TokenType.Char, token.getType());
@@ -679,7 +680,7 @@ public class ExpressionLexerUnitTest {
 
     token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(2, token.getValue(null));
+    assertEquals(2L, token.getValue(null));
     assertEquals(5, token.getStartIndex());
 
     token = this.lexer.scan();
@@ -689,7 +690,7 @@ public class ExpressionLexerUnitTest {
 
     token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(2, token.getValue(null));
+    assertEquals(2L, token.getValue(null));
     assertEquals(7, token.getStartIndex());
 
     token = this.lexer.scan();
@@ -704,7 +705,7 @@ public class ExpressionLexerUnitTest {
 
     token = this.lexer.scan();
     assertEquals(TokenType.Number, token.getType());
-    assertEquals(99, token.getValue(null));
+    assertEquals(99L, token.getValue(null));
     assertEquals(10, token.getStartIndex());
 
     assertNull(this.lexer.scan());

--- a/src/test/java/com/googlecode/aviator/runtime/function/custom/CustomFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/custom/CustomFunctionUnitTest.java
@@ -92,8 +92,8 @@ public class CustomFunctionUnitTest {
 
   @Test
   public void testMyAddFunction() {
-    assertEquals(10, AviatorEvaluator.execute("myadd(3,7)"));
-    assertEquals(10, AviatorEvaluator.exec("myadd(a,b)", 6, 4));
+    assertEquals(10L, AviatorEvaluator.execute("myadd(3,7)"));
+    assertEquals(10L, AviatorEvaluator.exec("myadd(a,b)", 6, 4));
   }
 
 }

--- a/src/test/java/com/googlecode/aviator/runtime/function/math/MathAbsFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/math/MathAbsFunctionUnitTest.java
@@ -21,31 +21,32 @@ public class MathAbsFunctionUnitTest extends BaseMathFunctionUnitTestForOneArgum
   @Test
   public void testCall() {
     Env env = TestUtils.getTestEnv();
-    assertEquals(3, this.function.call(env, AviatorNumber.valueOf(-3)).getValue(null));
+    assertEquals(3L, this.function.call(env, AviatorNumber.valueOf(-3)).getValue(null));
     assertEquals(3.9, this.function.call(env, AviatorNumber.valueOf(-3.9)).getValue(null));
-    assertEquals(400, this.function.call(env, AviatorNumber.valueOf(400)).getValue(null));
+    assertEquals(400L, this.function.call(env, AviatorNumber.valueOf(400)).getValue(null));
     assertEquals(new BigInteger("300000000000000000000000000000000"),
         this.function
             .call(env, AviatorNumber.valueOf(new BigInteger("-300000000000000000000000000000000")))
             .getValue(null));
-    assertEquals(new BigDecimal("300000000000000000000000000000000.0000002223333"),
-        this.function
+    assertEquals(new BigDecimal("300000000000000000000000000000000.0000002223333").longValue(),
+        ((BigDecimal) this.function
             .call(env,
                 AviatorNumber
                     .valueOf(new BigDecimal("-300000000000000000000000000000000.0000002223333")))
-            .getValue(null));
-    assertEquals(400, this.function.call(env, AviatorNumber.valueOf(400)).getValue(null));
+            .getValue(null)).longValue());
+    assertEquals(400L, this.function.call(env, AviatorNumber.valueOf(400)).getValue(null));
 
     env.put("a", 300);
     env.put("b", -3.14);
     env.put("c", new BigInteger("-300000000000000000000000000000000"));
     env.put("d", new BigDecimal("-300000000000000000000000000000000.0000002223333"));
 
-    assertEquals(300, this.function.call(env, new AviatorJavaType("a")).getValue(null));
+    assertEquals(300L, this.function.call(env, new AviatorJavaType("a")).getValue(null));
     assertEquals(3.14, this.function.call(env, new AviatorJavaType("b")).getValue(null));
     assertEquals(new BigInteger("300000000000000000000000000000000"),
         this.function.call(env, new AviatorJavaType("c")).getValue(null));
-    assertEquals(new BigDecimal("300000000000000000000000000000000.0000002223333"),
-        this.function.call(env, new AviatorJavaType("d")).getValue(null));
+    assertEquals(new BigDecimal("300000000000000000000000000000000.0000002223333").longValue(),
+        ((BigDecimal) this.function.call(env, new AviatorJavaType("d")).getValue(null))
+            .longValue());
   }
 }

--- a/src/test/java/com/googlecode/aviator/runtime/function/math/MathLog10FunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/math/MathLog10FunctionUnitTest.java
@@ -19,14 +19,16 @@ public class MathLog10FunctionUnitTest extends BaseMathFunctionUnitTestForOneArg
   public void testCall() {
     assertEquals(2.0, this.function.call(null, AviatorNumber.valueOf(100)).getValue(null));
     assertEquals(3.0, this.function.call(null, AviatorNumber.valueOf(1000)).getValue(null));
-    assertEquals(2.60, this.function.call(null, AviatorNumber.valueOf(400)).getValue(null));
+    assertEquals(2.60, (double) this.function.call(null, AviatorNumber.valueOf(400)).getValue(null),
+        0.01);
 
     Map<String, Object> env = new HashMap<String, Object>();
     env.put("a", 10000);
     env.put("b", 9.0);
 
     assertEquals(4.0, this.function.call(env, new AviatorJavaType("a")).getValue(null));
-    assertEquals(0.9542, this.function.call(env, new AviatorJavaType("b")).getValue(null));
+    assertEquals(0.9542, (double) this.function.call(env, new AviatorJavaType("b")).getValue(null),
+        0.0001);
   }
 
 }

--- a/src/test/java/com/googlecode/aviator/runtime/function/math/MathLogFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/math/MathLogFunctionUnitTest.java
@@ -21,20 +21,31 @@ public class MathLogFunctionUnitTest extends BaseMathFunctionUnitTestForOneArgum
   @Test
   public void testCall() {
     Env env = TestUtils.getTestEnv();
-    assertEquals(2.197, this.function.call(env, AviatorNumber.valueOf(9)).getValue(null));
-    assertEquals(4.394, this.function.call(env, AviatorNumber.valueOf(81)).getValue(null));
-    assertEquals(5.991, this.function.call(env, AviatorNumber.valueOf(400)).getValue(null));
+    assertEquals(2.197, (double) this.function.call(env, AviatorNumber.valueOf(9)).getValue(null),
+        0.001);
+    assertEquals(4.394, (double) this.function.call(env, AviatorNumber.valueOf(81)).getValue(null),
+        0.001);
+    assertEquals(5.991, (double) this.function.call(env, AviatorNumber.valueOf(400)).getValue(null),
+        0.001);
 
-    assertEquals(new BigDecimal("5.991"),
-        this.function.call(env, AviatorNumber.valueOf(new BigInteger("400"))).getValue(null));
-    assertEquals(new BigDecimal("6.907755268982137"),
-        this.function.call(env, AviatorNumber.valueOf(new BigDecimal("999.99999"))).getValue(null));
+    assertEquals(
+        new BigDecimal("5.991").doubleValue(), ((BigDecimal) this.function
+            .call(env, AviatorNumber.valueOf(new BigInteger("400"))).getValue(null)).doubleValue(),
+        0.001);
+    assertEquals(new BigDecimal("6.907755268982137").doubleValue(),
+        ((BigDecimal) this.function.call(env, AviatorNumber.valueOf(new BigDecimal("999.99999")))
+            .getValue(null)).doubleValue(),
+        1e-15);
 
     env.put("a", 400);
     env.put("b", 9.0);
 
-    assertEquals(5.991, this.function.call(env, new AviatorJavaType("a")).getValue(null));
-    assertEquals(2.197, this.function.call(env, new AviatorJavaType("b")).getValue(null));
+    assertEquals(5.991,
+        ((Number) this.function.call(env, new AviatorJavaType("a")).getValue(null)).doubleValue(),
+        0.001);
+    assertEquals(2.197,
+        ((Number) this.function.call(env, new AviatorJavaType("b")).getValue(null)).doubleValue(),
+        0.001);
   }
 
 }

--- a/src/test/java/com/googlecode/aviator/runtime/function/math/MathRoundFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/math/MathRoundFunctionUnitTest.java
@@ -18,18 +18,18 @@ public class MathRoundFunctionUnitTest extends BaseMathFunctionUnitTestForOneArg
 
   @Test
   public void testCall() {
-    assertEquals(Math.round(30),
+    assertEquals((long) Math.round(30),
         this.function.call(null, AviatorNumber.valueOf(30)).getValue(null));
     assertEquals(Math.round(1020.999),
         this.function.call(null, AviatorNumber.valueOf(1020.999)).getValue(null));
-    assertEquals(Math.round(400),
+    assertEquals((long) Math.round(400),
         this.function.call(null, AviatorNumber.valueOf(400)).getValue(null));
 
     Map<String, Object> env = new HashMap<String, Object>();
     env.put("a", 10000);
     env.put("b", 9.0);
 
-    assertEquals(Math.round(10000),
+    assertEquals((long) Math.round(10000),
         this.function.call(env, new AviatorJavaType("a")).getValue(null));
     assertEquals(Math.round(9.0), this.function.call(env, new AviatorJavaType("b")).getValue(null));
   }

--- a/src/test/java/com/googlecode/aviator/runtime/function/seq/SeqCountFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/seq/SeqCountFunctionUnitTest.java
@@ -15,7 +15,7 @@ public class SeqCountFunctionUnitTest {
     args[0] = AviatorRuntimeJavaType.valueOf(new String[10]);
     SeqCountFunction fun = new SeqCountFunction();
     AviatorObject result = fun.call(null, AviatorRuntimeJavaType.valueOf(new String[10]));
-    assertEquals(10, result.getValue(null));
+    assertEquals(10L, result.getValue(null));
   }
 
 
@@ -24,7 +24,7 @@ public class SeqCountFunctionUnitTest {
 
     SeqCountFunction fun = new SeqCountFunction();
     AviatorObject result = fun.call(null, AviatorRuntimeJavaType.valueOf(new String[0]));
-    assertEquals(0, result.getValue(null));
+    assertEquals(0L, result.getValue(null));
   }
 
 
@@ -36,7 +36,7 @@ public class SeqCountFunctionUnitTest {
 
     SeqCountFunction fun = new SeqCountFunction();
     AviatorObject result = fun.call(null, AviatorRuntimeJavaType.valueOf(set));
-    assertEquals(2, result.getValue(null));
+    assertEquals(2L, result.getValue(null));
   }
 
 
@@ -44,7 +44,7 @@ public class SeqCountFunctionUnitTest {
   public void testCount_String() {
     SeqCountFunction fun = new SeqCountFunction();
     AviatorObject result = fun.call(null, AviatorRuntimeJavaType.valueOf("hello"));
-    assertEquals(5, result.getValue(null));
+    assertEquals(5L, result.getValue(null));
   }
 
 }

--- a/src/test/java/com/googlecode/aviator/runtime/function/seq/SeqMapFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/seq/SeqMapFunctionUnitTest.java
@@ -28,7 +28,7 @@ public class SeqMapFunctionUnitTest {
         new AviatorJavaType("string.length"));
     Object[] array = (Object[]) result.getValue(null);
     for (Object i : array) {
-      assertEquals(5, i);
+      assertEquals(5L, i);
     }
   }
 
@@ -45,7 +45,7 @@ public class SeqMapFunctionUnitTest {
         fun.call(env, AviatorRuntimeJavaType.valueOf(strs), new AviatorJavaType("string.length"));
     LinkedList array = (LinkedList) result.getValue(env);
     for (Object i : array) {
-      assertEquals(5, i);
+      assertEquals(5L, i);
     }
   }
 
@@ -60,7 +60,7 @@ public class SeqMapFunctionUnitTest {
     List list = (List) result.getValue(null);
     assertEquals(5, list.size());
     for (Object val : list) {
-      assertEquals(val, 1);
+      assertEquals(1L, val);
     }
   }
 

--- a/src/test/java/com/googlecode/aviator/runtime/function/seq/SeqReduceFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/seq/SeqReduceFunctionUnitTest.java
@@ -36,7 +36,7 @@ public class SeqReduceFunctionUnitTest {
         (AviatorObject) AviatorEvaluator.execute("lambda(x, y) -> x + long(y.value) end"),
         AviatorRuntimeJavaType.valueOf(5));
     assertNotNull(result);
-    assertEquals(8, result.getValue(null));
+    assertEquals(8L, result.getValue(null));
   }
 
   @Test
@@ -50,7 +50,7 @@ public class SeqReduceFunctionUnitTest {
     AviatorObject result = fun.call(this.env, AviatorRuntimeJavaType.valueOf(a),
         new AviatorJavaType("+"), AviatorRuntimeJavaType.valueOf(0));
     assertNotNull(result);
-    assertEquals(45, result.getValue(null));
+    assertEquals(45L, result.getValue(null));
 
   }
 
@@ -82,7 +82,7 @@ public class SeqReduceFunctionUnitTest {
     AviatorObject result = fun.call(this.env, AviatorRuntimeJavaType.valueOf(a),
         new AviatorJavaType("+"), AviatorRuntimeJavaType.valueOf(0));
     assertNotNull(result);
-    assertEquals(45, result.getValue(null));
+    assertEquals(45L, result.getValue(null));
 
   }
 

--- a/src/test/java/com/googlecode/aviator/runtime/function/seq/SeqSortFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/seq/SeqSortFunctionUnitTest.java
@@ -27,7 +27,7 @@ public class SeqSortFunctionUnitTest {
     Integer[] dup = (Integer[]) result.getValue(null);
     assertFalse(Arrays.equals(a, dup));
     for (Integer i : dup) {
-      assertEquals(i, index++);
+      assertEquals(i.intValue(), index++);
     }
   }
 
@@ -48,7 +48,7 @@ public class SeqSortFunctionUnitTest {
     System.out.println(a);
     System.out.println(dup);
     for (Integer i : dup) {
-      assertEquals(i, index++);
+      assertEquals(i.intValue(), index++);
     }
   }
 

--- a/src/test/java/com/googlecode/aviator/runtime/function/string/StringLengthFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/string/StringLengthFunctionUnitTest.java
@@ -30,10 +30,10 @@ public class StringLengthFunctionUnitTest {
     env.put("s1", "hello");
     env.put("s2", "hello world");
 
-    assertEquals(5, function.call(null, new AviatorString("hello")).getValue(null));
-    assertEquals(11, function.call(null, new AviatorString("hello world")).getValue(null));
-    assertEquals(5, function.call(env, new AviatorJavaType("s1")).getValue(null));
-    assertEquals(11, function.call(env, new AviatorJavaType("s2")).getValue(null));
+    assertEquals(5L, function.call(null, new AviatorString("hello")).getValue(null));
+    assertEquals(11L, function.call(null, new AviatorString("hello world")).getValue(null));
+    assertEquals(5L, function.call(env, new AviatorJavaType("s1")).getValue(null));
+    assertEquals(11L, function.call(env, new AviatorJavaType("s2")).getValue(null));
 
   }
 

--- a/src/test/java/com/googlecode/aviator/runtime/type/AviatorJavaTypeUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/type/AviatorJavaTypeUnitTest.java
@@ -85,10 +85,10 @@ public class AviatorJavaTypeUnitTest {
 
     switch (operatorType) {
       case Add:
-        assertEquals(7, byteType.add(n1, env).getValue(null));
-        assertEquals(7, shortType.add(n1, env).getValue(null));
-        assertEquals(7, intType.add(n1, env).getValue(null));
-        assertEquals(7, longType.add(n1, env).getValue(null));
+        assertEquals(7L, byteType.add(n1, env).getValue(null));
+        assertEquals(7L, shortType.add(n1, env).getValue(null));
+        assertEquals(7L, intType.add(n1, env).getValue(null));
+        assertEquals(7L, longType.add(n1, env).getValue(null));
         assertEquals(7.4, (Double) floatType.add(n1, env).getValue(null), 0.001);
         assertEquals(7.4, (Double) doubleType.add(n1, env).getValue(null), 0.001);
         assertEquals(8L, byteType.add(intType, env).getValue(null));
@@ -98,10 +98,10 @@ public class AviatorJavaTypeUnitTest {
         assertEquals(7.7, (Double) n2.add(doubleType, env).getValue(null), 0.001);
         break;
       case Sub:
-        assertEquals(1, byteType.sub(n1, env).getValue(null));
-        assertEquals(1, shortType.sub(n1, env).getValue(null));
-        assertEquals(1, intType.sub(n1, env).getValue(null));
-        assertEquals(1, longType.sub(n1, env).getValue(null));
+        assertEquals(1L, byteType.sub(n1, env).getValue(null));
+        assertEquals(1L, shortType.sub(n1, env).getValue(null));
+        assertEquals(1L, intType.sub(n1, env).getValue(null));
+        assertEquals(1L, longType.sub(n1, env).getValue(null));
         assertEquals(1.4, (Double) floatType.sub(n1, env).getValue(null), 0.001);
         assertEquals(1.4, (Double) doubleType.sub(n1, env).getValue(null), 0.001);
         assertEquals(0L, byteType.sub(intType, env).getValue(null));
@@ -113,10 +113,10 @@ public class AviatorJavaTypeUnitTest {
 
       case Mult:
         // 4 4.4 3 3.3
-        assertEquals(12, byteType.mult(n1, env).getValue(null));
-        assertEquals(12, shortType.mult(n1, env).getValue(null));
-        assertEquals(12, intType.mult(n1, env).getValue(null));
-        assertEquals(12, longType.mult(n1, env).getValue(null));
+        assertEquals(12L, byteType.mult(n1, env).getValue(null));
+        assertEquals(12L, shortType.mult(n1, env).getValue(null));
+        assertEquals(12L, intType.mult(n1, env).getValue(null));
+        assertEquals(12L, longType.mult(n1, env).getValue(null));
         assertEquals(13.2, (Double) floatType.mult(n1, env).getValue(null), 0.001);
         assertEquals(13.2, (Double) doubleType.mult(n1, env).getValue(null), 0.001);
         assertEquals(16L, byteType.mult(intType, env).getValue(null));
@@ -126,10 +126,10 @@ public class AviatorJavaTypeUnitTest {
         assertEquals(14.52, (Double) n2.mult(doubleType, env).getValue(null), 0.001);
         break;
       case Div:
-        assertEquals(1, byteType.div(n1, env).getValue(null));
-        assertEquals(1, shortType.div(n1, env).getValue(null));
-        assertEquals(1, intType.div(n1, env).getValue(null));
-        assertEquals(1, longType.div(n1, env).getValue(null));
+        assertEquals(1L, byteType.div(n1, env).getValue(null));
+        assertEquals(1L, shortType.div(n1, env).getValue(null));
+        assertEquals(1L, intType.div(n1, env).getValue(null));
+        assertEquals(1L, longType.div(n1, env).getValue(null));
         assertEquals(1.466667, (Double) floatType.div(n1, env).getValue(null), 0.001);
         assertEquals(1.466667, (Double) doubleType.div(n1, env).getValue(null), 0.001);
         assertEquals(1L, byteType.div(intType, env).getValue(null));
@@ -139,10 +139,10 @@ public class AviatorJavaTypeUnitTest {
         assertEquals(0.75, (Double) n2.div(doubleType, env).getValue(null), 0.001);
         break;
       case Mod:
-        assertEquals(1, byteType.mod(n1, env).getValue(null));
-        assertEquals(1, shortType.mod(n1, env).getValue(null));
-        assertEquals(1, intType.mod(n1, env).getValue(null));
-        assertEquals(1, longType.mod(n1, env).getValue(null));
+        assertEquals(1L, byteType.mod(n1, env).getValue(null));
+        assertEquals(1L, shortType.mod(n1, env).getValue(null));
+        assertEquals(1L, intType.mod(n1, env).getValue(null));
+        assertEquals(1L, longType.mod(n1, env).getValue(null));
         assertEquals(1.4, (Double) floatType.mod(n1, env).getValue(null), 0.001);
         assertEquals(1.4, (Double) doubleType.mod(n1, env).getValue(null), 0.001);
         assertEquals(0L, byteType.mod(intType, env).getValue(null));

--- a/src/test/java/com/googlecode/aviator/runtime/type/AviatorNumberUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/type/AviatorNumberUnitTest.java
@@ -211,7 +211,6 @@ public class AviatorNumberUnitTest {
 
   @Test
   public void testSubWithJavaType() {
-
     this.doArithOperationWithJavaType(OperatorType.Sub);
   }
 
@@ -267,7 +266,7 @@ public class AviatorNumberUnitTest {
         a = AviatorNumber.valueOf(1000);
         assertEquals(1004.3, a.add(doubleType, env).getValue(null));
         a = AviatorNumber.valueOf(1000);
-        assertEquals(1004.3, a.add(floatType, env).getValue(null));
+        assertEquals(1004.3, (double) a.add(floatType, env).getValue(null), 0.1);
         break;
       case Sub:
         a = AviatorNumber.valueOf(1000);
@@ -281,7 +280,7 @@ public class AviatorNumberUnitTest {
         a = AviatorNumber.valueOf(1000);
         assertEquals(995.7d, a.sub(doubleType, env).getValue(null));
         a = AviatorNumber.valueOf(1000);
-        assertEquals(995.7d, a.sub(floatType, env).getValue(null));
+        assertEquals(995.7d, (double) a.sub(floatType, env).getValue(null), 0.1);
         break;
 
       case Mod:
@@ -379,25 +378,25 @@ public class AviatorNumberUnitTest {
     switch (operatorType) {
       case Add:
         this.reset();
-        assertEquals(6.3, this.a.add(this.b, env).getValue(env));
+        assertEquals(6.3, (double) this.a.add(this.b, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(6.3, this.b.add(this.a, env).getValue(env));
+        assertEquals(6.3, (double) this.b.add(this.a, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(7.6, this.a.add(this.d, env).getValue(env));
+        assertEquals(7.6, (double) this.a.add(this.d, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(7.6, this.d.add(this.a, env).getValue(env));
+        assertEquals(7.6, (double) this.d.add(this.a, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(1003, this.b.add(this.c, env).getValue(env));
+        assertEquals(1003L, this.b.add(this.c, env).getValue(env));
         this.reset();
-        assertEquals(1003, this.c.add(this.b, env).getValue(env));
+        assertEquals(1003L, this.c.add(this.b, env).getValue(env));
         this.reset();
-        assertEquals(7.3, this.b.add(this.d, env).getValue(env));
+        assertEquals(7.3, (double) this.b.add(this.d, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(7.3, this.d.add(this.b, env).getValue(env));
+        assertEquals(7.3, (double) this.d.add(this.b, env).getValue(env), 0.1);
 
         assertEquals(new BigInteger("92233720368547758074"), this.b.add(this.e, env).getValue(env));
         assertEquals(new BigInteger("92233720368547759071"), this.c.add(this.e, env).getValue(env));
-        assertEquals(9.223372036854776E18, this.a.add(this.e, env).getValue(env));
+        assertEquals(9.223372036854776E19, (double) this.a.add(this.e, env).getValue(env), 1E17);
 
         assertEquals(new BigDecimal("92233720368547758074.1001"),
             this.b.add(this.f, env).getValue(env));
@@ -407,21 +406,21 @@ public class AviatorNumberUnitTest {
         break;
       case Sub:
         this.reset();
-        assertEquals(0.3, this.a.sub(this.b, env).getValue(env));
+        assertEquals(0.3, (double) this.a.sub(this.b, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(-0.3, this.b.sub(this.a, env).getValue(env));
+        assertEquals(-0.3, (double) this.b.sub(this.a, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(-1.0, this.a.sub(this.d, env).getValue(env));
+        assertEquals(-1.0, (double) this.a.sub(this.d, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(1.0, this.d.sub(this.a, env).getValue(env));
+        assertEquals(1.0, (double) this.d.sub(this.a, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(-997, this.b.sub(this.c, env).getValue(env));
+        assertEquals(-997L, this.b.sub(this.c, env).getValue(env));
         this.reset();
-        assertEquals(997, this.c.sub(this.b, env).getValue(env));
+        assertEquals(997L, this.c.sub(this.b, env).getValue(env));
         this.reset();
-        assertEquals(-1.3, this.b.sub(this.d, env).getValue(env));
+        assertEquals(-1.3, (double) this.b.sub(this.d, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(1.3, this.d.sub(this.b, env).getValue(env));
+        assertEquals(1.3, (double) this.d.sub(this.b, env).getValue(env), 0.1);
 
         assertEquals(new BigInteger("-92233720368547758068"),
             this.b.sub(this.e, env).getValue(env));
@@ -437,33 +436,33 @@ public class AviatorNumberUnitTest {
         break;
       case Mult:
         this.reset();
-        assertEquals(9.9, this.a.mult(this.b, env).getValue(env));
+        assertEquals(9.9, (double) this.a.mult(this.b, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(9.9, this.b.mult(this.a, env).getValue(env));
+        assertEquals(9.9, (double) this.b.mult(this.a, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(14.19, this.a.mult(this.d, env).getValue(env));
+        assertEquals(14.19, (double) this.a.mult(this.d, env).getValue(env), 0.01);
         this.reset();
-        assertEquals(14.19, this.d.mult(this.a, env).getValue(env));
+        assertEquals(14.19, (double) this.d.mult(this.a, env).getValue(env), 0.01);
         this.reset();
-        assertEquals(3000, this.b.mult(this.c, env).getValue(env));
+        assertEquals(3000L, this.b.mult(this.c, env).getValue(env));
         this.reset();
-        assertEquals(3000, this.c.mult(this.b, env).getValue(env));
+        assertEquals(3000L, this.c.mult(this.b, env).getValue(env));
         this.reset();
-        assertEquals(12.9, this.b.mult(this.d, env).getValue(env));
+        assertEquals(12.9, (double) this.b.mult(this.d, env).getValue(env), 0.1);
         this.reset();
-        assertEquals(12.9, this.d.mult(this.b, env).getValue(env));
+        assertEquals(12.9, (double) this.d.mult(this.b, env).getValue(env), 0.1);
 
         assertEquals(new BigInteger("276701161105643274213"),
             this.b.mult(this.e, env).getValue(env));
         assertEquals(new BigInteger("92233720368547758071000"),
             this.c.mult(this.e, env).getValue(env));
-        assertEquals(3.043712772162076E20, this.a.mult(this.e, env).getValue(env));
+        assertEquals(3.043712772162076E20, (double) this.a.mult(this.e, env).getValue(env), 1e13);
 
         assertEquals(new BigDecimal("276701161105643274213.3003"),
             this.b.mult(this.f, env).getValue(env));
         assertEquals(new BigDecimal("92233720368547758071100.1000"),
             this.c.mult(this.f, env).getValue(env));
-        assertEquals(3.043712772162076E20, this.a.mult(this.f, env).getValue(env));
+        assertEquals(3.043712772162076E20, (double) this.a.mult(this.f, env).getValue(env), 1e13);
         break;
 
       case Div:
@@ -477,9 +476,9 @@ public class AviatorNumberUnitTest {
         this.reset();
         assertEquals(1.30303030, (Double) this.d.div(this.a, env).getValue(env), 0.001);
         this.reset();
-        assertEquals(0, this.b.div(this.c, env).getValue(env));
+        assertEquals(0L, this.b.div(this.c, env).getValue(env));
         this.reset();
-        assertEquals(333, this.c.div(this.b, env).getValue(env));
+        assertEquals(333L, this.c.div(this.b, env).getValue(env));
         this.reset();
         assertEquals(0.6976744, (Double) this.b.div(this.d, env).getValue(env), 0.001);
         this.reset();
@@ -487,13 +486,13 @@ public class AviatorNumberUnitTest {
 
         assertEquals(new BigInteger("30744573456182586023"), this.e.div(this.b, env).getValue(env));
         assertEquals(new BigInteger("92233720368547758"), this.e.div(this.c, env).getValue(env));
-        assertEquals(2.794961223289326E19, this.e.div(this.a, env).getValue(env));
+        assertEquals(2.794961223289326E19, (double) this.e.div(this.a, env).getValue(env), 1e12);
 
         assertEquals(new BigDecimal("3.252606517456513302336211867796323E-20"),
             this.b.div(this.f, env).getValue(env));
         assertEquals(new BigDecimal("1.084202172485504434112070622598774E-17"),
             this.c.div(this.f, env).getValue(env));
-        assertEquals(3.577867169202164E-20, this.a.div(this.f, env).getValue(env));
+        assertEquals(3.577867169202164E-20, (double) this.a.div(this.f, env).getValue(env), 1e-27);
         break;
       case Mod:
         this.reset();
@@ -505,9 +504,9 @@ public class AviatorNumberUnitTest {
         this.reset();
         assertEquals(1.0, (Double) this.d.mod(this.a, env).getValue(env), 0.001);
         this.reset();
-        assertEquals(3, this.b.mod(this.c, env).getValue(env));
+        assertEquals(3L, this.b.mod(this.c, env).getValue(env));
         this.reset();
-        assertEquals(1, this.c.mod(this.b, env).getValue(env));
+        assertEquals(1L, this.c.mod(this.b, env).getValue(env));
         this.reset();
         assertEquals(3.0, (Double) this.b.mod(this.d, env).getValue(env), 0.001);
         this.reset();
@@ -515,15 +514,15 @@ public class AviatorNumberUnitTest {
 
         assertEquals(new BigInteger("2"), this.e.mod(this.b, env).getValue(env));
         assertEquals(new BigInteger("71"), this.e.mod(this.c, env).getValue(env));
-        assertEquals(0.0, this.e.mod(this.a, env).getValue(env));
+        assertEquals(0.9, (double) this.e.mod(this.a, env).getValue(env), 0.1);
 
         assertEquals(new BigDecimal("3"), this.b.mod(this.f, env).getValue(env));
         assertEquals(new BigDecimal("1000"), this.c.mod(this.f, env).getValue(env));
-        assertEquals(3.3, this.a.mod(this.f, env).getValue(env));
+        assertEquals(3.3, (double) this.a.mod(this.f, env).getValue(env), 0.1);
 
         assertEquals(new BigDecimal("2.1001"), this.f.mod(this.b, env).getValue(env));
         assertEquals(new BigDecimal("71.1001"), this.f.mod(this.c, env).getValue(env));
-        assertEquals(0.0, this.f.mod(this.a, env).getValue(env));
+        assertEquals(0.9, (double) this.f.mod(this.a, env).getValue(env), 0.1);
         break;
     }
   }

--- a/src/test/java/com/googlecode/aviator/spring/SringContextFunctionLoaderTest.java
+++ b/src/test/java/com/googlecode/aviator/spring/SringContextFunctionLoaderTest.java
@@ -21,7 +21,7 @@ public class SringContextFunctionLoaderTest {
 
   @Test
   public void testAdd() {
-    assertEquals(100, AviatorEvaluator.exec("springAdd(x,y)", 1, 99));
+    assertEquals(100.0, AviatorEvaluator.exec("springAdd(x,y)", 1, 99));
   }
 
   @AfterClass

--- a/src/test/java/com/googlecode/aviator/test/function/FunctionTest.java
+++ b/src/test/java/com/googlecode/aviator/test/function/FunctionTest.java
@@ -1078,16 +1078,16 @@ public class FunctionTest {
 
   @Test
   public void testTuple() {
-    assertArrayEquals(new Object[] {1, "hello", 3.2},
+    assertArrayEquals(new Object[] {1L, "hello", 3.2},
         (Object[]) AviatorEvaluator.execute("tuple(1,'hello',3.2)"));
-    assertArrayEquals(new Object[] {1, 2}, (Object[]) AviatorEvaluator.execute("tuple(1,2)"));
+    assertArrayEquals(new Object[] {1L, 2L}, (Object[]) AviatorEvaluator.execute("tuple(1,2)"));
     assertArrayEquals(new Object[] {}, (Object[]) AviatorEvaluator.execute("tuple()"));
     assertEquals(3, AviatorEvaluator.execute("count(tuple(1,'hello',3.2))"));
     assertEquals(3.2, AviatorEvaluator.execute("tuple(1,'hello',3.2)[2]"));
-    assertArrayEquals(new Object[] {2, 3, 4},
+    assertArrayEquals(new Object[] {2L, 3L, 4L},
         (Object[]) AviatorEvaluator.execute("map(tuple(1,2,3), lambda(x) -> x +1 end)"));
 
-    assertEquals(1, AviatorEvaluator.execute("seq.get(tuple(1,'hello',3.2), 0)"));
+    assertEquals(1L, AviatorEvaluator.execute("seq.get(tuple(1,'hello',3.2), 0)"));
     assertEquals("hello", AviatorEvaluator.execute("seq.get(tuple(1,'hello',3.2), 1)"));
     assertEquals(3.2, AviatorEvaluator.execute("seq.get(tuple(1,'hello',3.2), 2)"));
 

--- a/src/test/java/com/googlecode/aviator/test/function/QuoteVarTest.java
+++ b/src/test/java/com/googlecode/aviator/test/function/QuoteVarTest.java
@@ -94,6 +94,6 @@ public class QuoteVarTest {
 
     assertEquals("bar", AviatorEvaluator.execute("#foo.bars[0].name", env));
     assertEquals("hello,bar", AviatorEvaluator.execute("'hello,' + #foo.bars[0].name", env));
-    assertEquals(3, AviatorEvaluator.execute("string.length(#foo.bars[0].name)", env));
+    assertEquals(3L, AviatorEvaluator.execute("string.length(#foo.bars[0].name)", env));
   }
 }

--- a/src/test/java/com/googlecode/aviator/utils/LRUMapUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/utils/LRUMapUnitTest.java
@@ -24,7 +24,7 @@ public class LRUMapUnitTest {
     for (int i = 0; i < 5; i++) {
       assertNull(this.map.get(i));
       this.map.put(i, i);
-      assertEquals(i, this.map.get(i));
+      assertEquals(i, this.map.get(i).intValue());
     }
     assertEquals(5, map.size());
   }
@@ -35,13 +35,13 @@ public class LRUMapUnitTest {
     for (int i = 0; i < 20; i++) {
       assertNull(this.map.get(i));
       this.map.put(i, i);
-      assertEquals(i, this.map.get(i));
+      assertEquals(i, this.map.get(i).intValue());
     }
     assertEquals(10, map.size());
     for (int i = 0; i < 10; i++)
       assertNull(this.map.get(0));
     for (int i = 10; i < 11; i++)
-      assertEquals(i, this.map.get(i));
+      assertEquals(i, this.map.get(i).intValue());
     assertEquals(10, map.size());
 
   }

--- a/src/test/java/com/googlecode/aviator/utils/SyncLRUMapUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/utils/SyncLRUMapUnitTest.java
@@ -24,7 +24,7 @@ public class SyncLRUMapUnitTest {
     for (int i = 0; i < 5; i++) {
       assertNull(this.map.get(i));
       this.map.put(i, i);
-      assertEquals(i, this.map.get(i));
+      assertEquals(i, this.map.get(i).intValue());
     }
     assertEquals(5, map.size());
   }
@@ -35,13 +35,13 @@ public class SyncLRUMapUnitTest {
     for (int i = 0; i < 20; i++) {
       assertNull(this.map.get(i));
       this.map.put(i, i);
-      assertEquals(i, this.map.get(i));
+      assertEquals(i, this.map.get(i).intValue());
     }
     assertEquals(10, map.size());
     for (int i = 0; i < 10; i++)
       assertNull(this.map.get(0));
     for (int i = 10; i < 11; i++)
-      assertEquals(i, this.map.get(i));
+      assertEquals(i, this.map.get(i).intValue());
     assertEquals(10, map.size());
 
   }

--- a/src/test/resources/lib/test_math.av
+++ b/src/test/resources/lib/test_math.av
@@ -1,8 +1,8 @@
 
-j.assertEquals(0.3, math.asin(0.3));
-j.assertEquals(1.2661036727794992, math.acos(0.3));
-j.assertEquals(0.2914567944778671, math.atan(0.3));
-j.assertEquals(6.0, math.ceil(5.5));
-j.assertEquals(5.0, math.floor(5.5));
-j.assertEquals(6.0, math.ceil(5.1));
-j.assertEquals(5.0, math.floor(5.1));
+j.assertEquals(0.3, math.asin(0.3), 0.01);
+j.assertEquals(1.2661036727794992, math.acos(0.3),1e-15);
+j.assertEquals(0.2914567944778671, math.atan(0.3),1e-15);
+j.assertEquals(6.0, math.ceil(5.5),1e-15);
+j.assertEquals(5.0, math.floor(5.5),1e-15);
+j.assertEquals(6.0, math.ceil(5.1),1e-15);
+j.assertEquals(5.0, math.floor(5.1),1e-15);

--- a/src/test/resources/lib/test_var.av
+++ b/src/test/resources/lib/test_var.av
@@ -8,7 +8,7 @@ let foo = new VariableExample$Foo(-100, 99.9, new Date());
 j.assertNotNull(foo);
 j.assertTrue(is_a(foo, VariableExample$Foo));
 j.assertEquals(-100, foo.i);
-j.assertEquals(99.9, foo.f);
+j.assertEquals(99.9, foo.f,0.01);
 j.assertTrue(is_a(foo.date, Date));
 j.assertNotNull(foo.bars);
 j.assertNotNull(foo.bars[0]);
@@ -31,7 +31,7 @@ j.assertEquals("test value", seq.get(foo.context, "another"));
 foo.i = 1;
 j.assertEquals(1, foo.i);
 foo.f = 2.2;
-j.assertEquals(2.2, foo.f);
+j.assertEquals(2.2, foo.f, 0.01);
 
 #`foo.bars.[0]` = new VariableExample$Bar("bar1");
 j.assertEquals("bar1", #`foo.bars.[0].name`);


### PR DESCRIPTION
to issue #353

Intellij 无法单个运行 4.3.1 的 junit 测试，故升级到 4.12，并且修复了和 4.12 不兼容以及有问题的单测。

4.3 和 4.12 主要的兼容性问题在于，增加了很多基本类型 assertEquals，和原先 aviator 中大量使用的 assertEquals(Object,Object) 存在冲突。

另外 4.3 junit 的 assertEquals(Object,Object) 在比较浮点数时存在严重的 bug，它是将数字转成 long 进行比较的， 会造成浮点数比较不准，相关 junit 源码如下：

```java
        // junit 4.3 的 assertEquals(Object,Object) 实现
	private static boolean isEquals(Object expected, Object actual) {
                // 数字转成 long 进行比较
		if (expected instanceof Number && actual instanceof Number)
			return ((Number) expected).longValue() == ((Number) actual).longValue();
		return expected.equals(actual);
	}
```

在 aviator 的单测中经常有如下写法：

```java
// AviatorNumberUnitTest.java, 当然还有非常多的地方这么写
assertEquals(-0.3, this.b.sub(this.a, env).getValue(env));
```

这个最终调用的就是 assertEquals(Object,Object)，被转成 long 比较的，就算把改成 `assertEquals(-0.1, this.b.sub(this.a, env).getValue(env));`，该测试也是可以跑过的，没有起到比较效果。

在修改这些地方的过程我也发现 Aviator 的浮点数计算精度存在很大问题，但是之前的单测应为 junit 4.3 的 bug，都没有暴露出来，换成 4.12 后暴露无疑。
