### PR TITLE
支持对象和数组嵌套型变量，前面不用加 #

### DIFF
--- a/src/main/java/com/googlecode/aviator/lexer/ExpressionLexer.java
+++ b/src/main/java/com/googlecode/aviator/lexer/ExpressionLexer.java
@@ -351,6 +351,37 @@ public class ExpressionLexer {
       variable.setQuote(true);
       return this.symbolTable.reserve(variable);
     }
+    // 支持对象和数组嵌套型变量，前面不用加 #
+    if (Character.isJavaIdentifierStart(this.peek)) {
+      char oldPeek = peek;
+      int startIndex = this.iterator.getIndex();
+
+      StringBuilder sb = new StringBuilder();
+      int dots = 0;
+      int brackets = 0;
+
+      while (Character.isJavaIdentifierPart(this.peek) || this.peek == '.' || this.peek == '['
+              || this.peek == ']') {
+        if(this.peek == '.'){
+          dots++;
+        }
+        if(this.peek == '[' || this.peek == ']'){
+          brackets++;
+        }
+        sb.append(this.peek);
+        nextChar();
+      }
+      String lexeme = sb.toString();
+      // 同时出现点号和中括号，是对象和数组混合型变量
+      if(dots > 0 && brackets > 0){
+        Variable variable = new Variable(lexeme, this.lineNo, startIndex);
+        variable.setQuote(true);
+        return this.symbolTable.reserve(variable);
+      }else{
+        this.iterator.setIndex(startIndex);
+        this.peek = oldPeek;
+      }
+    }
     if (Character.isJavaIdentifierStart(this.peek)) {
       int startIndex = this.iterator.getIndex();
       StringBuilder sb = new StringBuilder();

--- a/src/test/java/com/googlecode/aviator/example/VariableExample.java
+++ b/src/test/java/com/googlecode/aviator/example/VariableExample.java
@@ -134,6 +134,13 @@ public class VariableExample {
     System.out.println("Execute expression: " + exp);
     System.out.println("Result: " + result);
     System.out.println(foo.bars[0].getName());
+    
+    // 不加 # 也可以
+    exp = "foo.bars[0].name='hello aviator' ; foo.bars[0].name";
+    result = (String) AviatorEvaluator.execute(exp, env);
+    System.out.println("Execute expression without sharp: " + exp);
+    System.out.println("Result: " + result);
+    System.out.println(foo.bars[0].getName());
 
     exp = "foo.bars[0] = nil ; foo.bars[0]";
     result = (String) AviatorEvaluator.execute(exp, env);


### PR DESCRIPTION
之前使用对象和数组嵌套型变量的时候，前面需要加 # 号，如：#foo.bars[0].name ，或者写成 foo['bars'][0]['name] 略有点麻烦。
修改的方式是在Lexer的时候检测都嵌套型变量，自动按照引用变量来处理，这样就不用再脚本里自己加 # 号了。