### PR TITLE
set ScriptEngineFactory.getLanguageName return aviator

### DIFF
--- a/src/main/java/com/googlecode/aviator/script/AviatorScriptEngineFactory.java
+++ b/src/main/java/com/googlecode/aviator/script/AviatorScriptEngineFactory.java
@@ -31,7 +31,7 @@ public class AviatorScriptEngineFactory implements ScriptEngineFactory {
   static {
     PARAM_MAP.put(ScriptEngine.ENGINE, "Aviator");
     PARAM_MAP.put(ScriptEngine.ENGINE_VERSION, AviatorEvaluator.VERSION);
-    PARAM_MAP.put(ScriptEngine.LANGUAGE, "A high performance scripting language hosted on the JVM");
+    PARAM_MAP.put(ScriptEngine.LANGUAGE, "aviator");
     PARAM_MAP.put(ScriptEngine.LANGUAGE_VERSION, AviatorEvaluator.VERSION);
   }
 

--- a/src/main/java/com/googlecode/aviator/script/AviatorScriptEngineFactory.java
+++ b/src/main/java/com/googlecode/aviator/script/AviatorScriptEngineFactory.java
@@ -31,7 +31,7 @@ public class AviatorScriptEngineFactory implements ScriptEngineFactory {
   static {
     PARAM_MAP.put(ScriptEngine.ENGINE, "Aviator");
     PARAM_MAP.put(ScriptEngine.ENGINE_VERSION, AviatorEvaluator.VERSION);
-    PARAM_MAP.put(ScriptEngine.LANGUAGE, "aviator");
+    PARAM_MAP.put(ScriptEngine.LANGUAGE, "AviatorScript");
     PARAM_MAP.put(ScriptEngine.LANGUAGE_VERSION, AviatorEvaluator.VERSION);
   }
 


### PR DESCRIPTION
Graal.js return ECMAScript
scala return Scala
jruby return ruby
Luaj return lua
Groovy return Groovy
BeanShell return BeanShell
kotlin return kotlin
rhino return javascript
Nashorn return ECMAScript
jython return python

Before Aviator return "A high performance scripting language hosted on the JVM"  

Now return "aviator"