### PR TITLE
将遇到无法解析的类符号的场景也纳入缓存管理，避免重复加载类。可在一定程度降低线程block的概率。-3，解决当加载java.la… …ng.成功未放入缓存的问题

### DIFF
--- a/src/main/java/com/googlecode/aviator/utils/Env.java
+++ b/src/main/java/com/googlecode/aviator/utils/Env.java
@@ -188,7 +188,7 @@ public class Env implements Map<String, Object> {
       // java.lang.XXX
       clazz = classForName("java.lang." + name);
       if (clazz != null) {
-        put2cache(name,NullClass.class);
+        put2cache(name, clazz);
         return checkIfClassIsAllowed(checkIfAllow, clazz);
       }
       // from imported packages


### PR DESCRIPTION
bugifx