### PR TITLE
feat: v.5.4.2 dev branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
   <artifactId>aviator</artifactId>
   <version>5.4.2-SNAPSHOT</version>
   <name>aviator</name>
-  <description>A lightweight, high performance expression evaluator for java</description>
+  <description>A high performance scripting language hosted on the JVM</description>
   <url>https://github.com/killme2008/aviator</url>
   <inceptionYear>2010</inceptionYear>
 
   <developers>
     <developer>
       <name>dennis zhuang</name>
-      <url>http://fnil.net/</url>
+      <url>https://github.com/killme2008</url>
       <timezone>8</timezone>
     </developer>
   </developers>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>4.3.16.RELEASE</version>
+      <version>5.3.36</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -118,8 +118,8 @@
 	<artifactId>maven-compiler-plugin</artifactId>
 	<version>3.8.1</version>
 	<configuration>
-	  <source>1.7</source>
-	  <target>1.7</target>
+	  <source>1.8</source>
+	  <target>1.8</target>
 	  <encoding>UTF-8</encoding>
 	</configuration>
       </plugin>

--- a/src/main/java/com/googlecode/aviator/AviatorEvaluatorInstance.java
+++ b/src/main/java/com/googlecode/aviator/AviatorEvaluatorInstance.java
@@ -407,7 +407,7 @@ public final class AviatorEvaluatorInstance {
     final Map<String, Object> module = exp.newEnv("exports", exports, "path", abPath);
     Map<String, Object> env = exp.newEnv("__MODULE__", module, "exports", exports);
     exp.execute(env);
-    exports.configure(this, exp);
+    exports.configure(this, exp, Utils.currentTimeNanos());
     return (Map<String, Object>) module.get("exports");
   }
 

--- a/src/main/java/com/googlecode/aviator/AviatorEvaluatorInstance.java
+++ b/src/main/java/com/googlecode/aviator/AviatorEvaluatorInstance.java
@@ -404,10 +404,11 @@ public final class AviatorEvaluatorInstance {
   @SuppressWarnings("unchecked")
   private Map<String, Object> executeModule(final Expression exp, final String abPath) {
     final Env exports = new Env();
+    exports.configure(this, exp, -1);
     final Map<String, Object> module = exp.newEnv("exports", exports, "path", abPath);
     Map<String, Object> env = exp.newEnv("__MODULE__", module, "exports", exports);
-    exp.execute(env);
-    exports.configure(this, exp, Utils.currentTimeNanos());
+    ((BaseExpression) exp).execute(env, false);
+
     return (Map<String, Object>) module.get("exports");
   }
 

--- a/src/main/java/com/googlecode/aviator/BaseExpression.java
+++ b/src/main/java/com/googlecode/aviator/BaseExpression.java
@@ -241,13 +241,16 @@ public abstract class BaseExpression implements Expression {
 
   public abstract Object executeDirectly(final Map<String, Object> env);
 
-
   @Override
   public Object execute(Map<String, Object> map) {
+    return this.execute(map, true);
+  }
+
+  protected Object execute(Map<String, Object> map, boolean checkExecutionTimeout) {
     if (map == null) {
       map = Collections.emptyMap();
     }
-    Env env = genTopEnv(map);
+    Env env = genTopEnv(map, checkExecutionTimeout);
     EnvProcessor envProcessor = this.instance.getEnvProcessor();
     if (envProcessor != null) {
       envProcessor.beforeExecute(env, this);
@@ -330,23 +333,25 @@ public abstract class BaseExpression implements Expression {
     return this.varNames;
   }
 
-  protected Env newEnv(final Map<String, Object> map, final boolean direct) {
+  protected Env newEnv(final Map<String, Object> map, final boolean direct,
+      boolean checkExecutionTimeout) {
     Env env;
     if (direct) {
       env = new Env(map, map == Collections.EMPTY_MAP ? new HashMap<String, Object>() : map);
     } else {
       env = new Env(map);
     }
-    env.configure(this.instance, this, Utils.currentTimeNanos());
+    env.configure(this.instance, this, getExecutionStartNs(checkExecutionTimeout));
     return env;
   }
 
-  protected Env genTopEnv(final Map<String, Object> map) {
+  protected Env genTopEnv(final Map<String, Object> map, boolean checkExecutionTimeout) {
     if (map instanceof Env) {
-      ((Env) map).configure(this.instance, this, Utils.currentTimeNanos());
+      ((Env) map).configure(this.instance, this, getExecutionStartNs(checkExecutionTimeout));
     }
     Env env =
-        newEnv(map, this.instance.getOptionValue(Options.USE_USER_ENV_AS_TOP_ENV_DIRECTLY).bool);
+        newEnv(map, this.instance.getOptionValue(Options.USE_USER_ENV_AS_TOP_ENV_DIRECTLY).bool,
+            checkExecutionTimeout);
 
     if (this.compileEnv != null && !this.compileEnv.isEmpty()) {
       env.putAll(this.compileEnv);
@@ -357,8 +362,16 @@ public abstract class BaseExpression implements Expression {
     return env;
   }
 
+  private long getExecutionStartNs(boolean checkExecutionTimeout) {
+    long startNs = -1;
+    if (checkExecutionTimeout && this.instance.getOptionValue(Options.EVAL_TIMEOUT_MS).number > 0) {
+      startNs = Utils.currentTimeNanos();
+    }
+    return startNs;
+  }
+
   protected Env newEnv(final Map<String, Object> map) {
-    return newEnv(map, false);
+    return newEnv(map, false, true);
   }
 
   public Map<String, LambdaFunctionBootstrap> getLambdaBootstraps() {

--- a/src/main/java/com/googlecode/aviator/BaseExpression.java
+++ b/src/main/java/com/googlecode/aviator/BaseExpression.java
@@ -24,6 +24,7 @@ import com.googlecode.aviator.parser.CompileTypes;
 import com.googlecode.aviator.parser.VariableMeta;
 import com.googlecode.aviator.runtime.FunctionArgument;
 import com.googlecode.aviator.runtime.LambdaFunctionBootstrap;
+import com.googlecode.aviator.runtime.RuntimeUtils;
 import com.googlecode.aviator.runtime.function.LambdaFunction;
 import com.googlecode.aviator.utils.Constants;
 import com.googlecode.aviator.utils.Env;
@@ -239,6 +240,7 @@ public abstract class BaseExpression implements Expression {
   }
 
   public abstract Object executeDirectly(final Map<String, Object> env);
+
 
   @Override
   public Object execute(Map<String, Object> map) {

--- a/src/main/java/com/googlecode/aviator/BaseExpression.java
+++ b/src/main/java/com/googlecode/aviator/BaseExpression.java
@@ -28,6 +28,7 @@ import com.googlecode.aviator.runtime.function.LambdaFunction;
 import com.googlecode.aviator.utils.Constants;
 import com.googlecode.aviator.utils.Env;
 import com.googlecode.aviator.utils.Reflector;
+import com.googlecode.aviator.utils.Utils;
 
 /**
  * Base expression
@@ -334,13 +335,13 @@ public abstract class BaseExpression implements Expression {
     } else {
       env = new Env(map);
     }
-    env.configure(this.instance, this);
+    env.configure(this.instance, this, Utils.currentTimeNanos());
     return env;
   }
 
   protected Env genTopEnv(final Map<String, Object> map) {
     if (map instanceof Env) {
-      ((Env) map).configure(this.instance, this);
+      ((Env) map).configure(this.instance, this, Utils.currentTimeNanos());
     }
     Env env =
         newEnv(map, this.instance.getOptionValue(Options.USE_USER_ENV_AS_TOP_ENV_DIRECTLY).bool);

--- a/src/main/java/com/googlecode/aviator/Options.java
+++ b/src/main/java/com/googlecode/aviator/Options.java
@@ -117,9 +117,20 @@ public enum Options {
 
   /**
    * Whether the compiled expression is serializable. If true, the compiled expression will
-   * implement {@link #jva.io.Serializable} and can be encoded/decoded by java serialization.
+   * implement {@link jva.io.Serializable} and can be encoded/decoded by java serialization.
    */
-  SERIALIZABLE;
+  SERIALIZABLE,
+
+  /**
+   * 
+   * The expression execution timeout value in milliseconds. If the execution time exceeds this
+   * value, it will throw a {@link com.googlecode.aviator.exception.TimeoutException}. A value of
+   * zero or less indicates no timeout limitation, the default value is zero (no limitation).
+   * 
+   * @since 5.5.0
+   * 
+   */
+  EVAL_TIMEOUT_MS;
 
 
   /**
@@ -200,6 +211,7 @@ public enum Options {
         return val.bool;
       case MAX_LOOP_COUNT:
       case OPTIMIZE_LEVEL:
+      case EVAL_TIMEOUT_MS:
         return val.number;
       case FEATURE_SET:
         return val.featureSet;
@@ -243,6 +255,7 @@ public enum Options {
           return COMPILE_VALUE;
         }
       }
+      case EVAL_TIMEOUT_MS:
       case MAX_LOOP_COUNT:
         return new Value(((Number) val).intValue());
       case ALLOWED_CLASS_SET:
@@ -278,6 +291,7 @@ public enum Options {
         final int level = ((Integer) val).intValue();
         return val instanceof Integer
             && (level == AviatorEvaluator.EVAL || level == AviatorEvaluator.COMPILE);
+      case EVAL_TIMEOUT_MS:
       case MAX_LOOP_COUNT:
         return val instanceof Long || val instanceof Integer;
       case MATH_CONTEXT:
@@ -356,6 +370,8 @@ public enum Options {
         return NULL_CLASS_SET;
       case EVAL_MODE:
         return getDefaultEvalMode();
+      case EVAL_TIMEOUT_MS:
+        return ZERO_VALUE;
     }
     return null;
   }

--- a/src/main/java/com/googlecode/aviator/Options.java
+++ b/src/main/java/com/googlecode/aviator/Options.java
@@ -2,6 +2,7 @@ package com.googlecode.aviator;
 
 import java.math.MathContext;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import com.googlecode.aviator.utils.Utils;
 
 
@@ -125,7 +126,17 @@ public enum Options {
    * 
    * The expression execution timeout value in milliseconds. If the execution time exceeds this
    * value, it will throw a {@link com.googlecode.aviator.exception.TimeoutException}. A value of
-   * zero or less indicates no timeout limitation, the default value is zero (no limitation).
+   * zero or less indicates no timeout limitation, the default value is zero (no limitation). <br/>
+   * <br/>
+   * Note: this limitation is not strict and may hurt performance, it is only checked before:
+   * <ul>
+   * <li>Operator evaluating, such as add, sub etc.</li>
+   * <li>Jumping in branches, such as loop and conditional clauses etc.</li>
+   * <li>Function invocation</li>
+   * </ul>
+   * 
+   * So if the expression doesn't contains these clauses or trapped into a function invocation, the
+   * behavior may be not expected.
    * 
    * @since 5.5.0
    * 
@@ -146,6 +157,8 @@ public enum Options {
     public Set<Feature> featureSet;
     public Set<Class<?>> classes;
     public EvalMode evalMode;
+    // Temporal cached number value to avoid expensive calculation.
+    public long cachedNumber;
 
     public Value(final EvalMode evalMode) {
       super();
@@ -255,7 +268,15 @@ public enum Options {
           return COMPILE_VALUE;
         }
       }
-      case EVAL_TIMEOUT_MS:
+      case EVAL_TIMEOUT_MS: {
+        Value value = new Value(((Number) val).intValue());
+        // Cached the converted result.
+        if (value.number > 0) {
+          value.cachedNumber =
+              (int) TimeUnit.NANOSECONDS.convert(value.number, TimeUnit.MILLISECONDS);
+        }
+        return value;
+      }
       case MAX_LOOP_COUNT:
         return new Value(((Number) val).intValue());
       case ALLOWED_CLASS_SET:

--- a/src/main/java/com/googlecode/aviator/Options.java
+++ b/src/main/java/com/googlecode/aviator/Options.java
@@ -136,9 +136,9 @@ public enum Options {
    * </ul>
    * 
    * So if the expression doesn't contains these clauses or trapped into a function invocation, the
-   * behavior may be not expected.
+   * behavior may be not expected. Try its best, but no promises.
    * 
-   * @since 5.5.0
+   * @since 5.4.2
    * 
    */
   EVAL_TIMEOUT_MS;
@@ -272,8 +272,7 @@ public enum Options {
         Value value = new Value(((Number) val).intValue());
         // Cached the converted result.
         if (value.number > 0) {
-          value.cachedNumber =
-              (int) TimeUnit.NANOSECONDS.convert(value.number, TimeUnit.MILLISECONDS);
+          value.cachedNumber = TimeUnit.NANOSECONDS.convert(value.number, TimeUnit.MILLISECONDS);
         }
         return value;
       }

--- a/src/main/java/com/googlecode/aviator/code/OptimizeCodeGenerator.java
+++ b/src/main/java/com/googlecode/aviator/code/OptimizeCodeGenerator.java
@@ -373,6 +373,10 @@ public class OptimizeCodeGenerator implements CodeGenerator {
           if (SymbolTable.isReservedKeyword((Variable) token)) {
             continue;
           }
+          // Ignore class name or package name
+          if (token.getMeta(Constants.USE_CLASS_PKG, false)) {
+            continue;
+          }
 
           String varName = token.getLexeme();
           VariableMeta meta = variables.get(varName);

--- a/src/main/java/com/googlecode/aviator/code/interpreter/IR.java
+++ b/src/main/java/com/googlecode/aviator/code/interpreter/IR.java
@@ -10,4 +10,13 @@ import java.io.Serializable;
  */
 public interface IR extends Serializable {
   void eval(InterpretContext context);
+
+  /**
+   * Returns true when the IR execution cost may be expensive
+   * 
+   * @return
+   */
+  default boolean mayBeCost() {
+    return false;
+  }
 }

--- a/src/main/java/com/googlecode/aviator/code/interpreter/InterpretContext.java
+++ b/src/main/java/com/googlecode/aviator/code/interpreter/InterpretContext.java
@@ -28,7 +28,6 @@ public class InterpretContext {
   private final InterpretExpression expression;
   private boolean reachEnd;
   private final boolean trace;
-  private long startNs = -1;
   private long evalTimeoutNs = 0;
 
 
@@ -41,7 +40,6 @@ public class InterpretContext {
     long ms = RuntimeUtils.getEvalTimeoutMs(env);
     if (ms > 0) {
       this.evalTimeoutNs = TimeUnit.NANOSECONDS.convert(ms, TimeUnit.MILLISECONDS);
-      this.startNs = System.nanoTime();
     }
     next();
   }
@@ -147,8 +145,8 @@ public class InterpretContext {
     }
 
     // Check whether it's execution is timed out.
-    if (this.startNs > 0) {
-      if (System.nanoTime() - this.startNs > this.evalTimeoutNs) {
+    if (this.evalTimeoutNs > 0 && this.env.getStartNs() > 0) {
+      if (System.nanoTime() - this.env.getStartNs() > this.evalTimeoutNs) {
         throw new TimeoutException("Expression execution timed out, exceeded: "
             + RuntimeUtils.getEvalTimeoutMs(env) + " ms");
       }

--- a/src/main/java/com/googlecode/aviator/code/interpreter/ir/BranchIfIR.java
+++ b/src/main/java/com/googlecode/aviator/code/interpreter/ir/BranchIfIR.java
@@ -41,6 +41,13 @@ public class BranchIfIR implements IR, JumpIR {
     }
   }
 
+
+
+  @Override
+  public boolean mayBeCost() {
+    return true;
+  }
+
   @Override
   public String toString() {
     return "branch_if " + this.pc + "  [" + this.label + "]      " + this.sourceInfo;

--- a/src/main/java/com/googlecode/aviator/code/interpreter/ir/BranchUnlessIR.java
+++ b/src/main/java/com/googlecode/aviator/code/interpreter/ir/BranchUnlessIR.java
@@ -43,6 +43,11 @@ public class BranchUnlessIR implements IR, JumpIR {
   }
 
   @Override
+  public boolean mayBeCost() {
+    return true;
+  }
+
+  @Override
   public String toString() {
     return "branch_unless " + this.pc + "  [" + this.label + "]      " + this.sourceInfo;
   }

--- a/src/main/java/com/googlecode/aviator/code/interpreter/ir/GotoIR.java
+++ b/src/main/java/com/googlecode/aviator/code/interpreter/ir/GotoIR.java
@@ -31,6 +31,11 @@ public class GotoIR implements IR, JumpIR {
   }
 
   @Override
+  public boolean mayBeCost() {
+    return true;
+  }
+
+  @Override
   public void eval(final InterpretContext context) {
     context.jumpTo(this.pc);
     context.dispatch(false);

--- a/src/main/java/com/googlecode/aviator/code/interpreter/ir/OperatorIR.java
+++ b/src/main/java/com/googlecode/aviator/code/interpreter/ir/OperatorIR.java
@@ -110,7 +110,10 @@ public class OperatorIR implements IR {
     context.dispatch();
   }
 
-
+  @Override
+  public boolean mayBeCost() {
+    return true;
+  }
 
   public OperatorType getOp() {
     return this.op;

--- a/src/main/java/com/googlecode/aviator/code/interpreter/ir/SendIR.java
+++ b/src/main/java/com/googlecode/aviator/code/interpreter/ir/SendIR.java
@@ -139,6 +139,11 @@ public class SendIR implements IR {
   }
 
   @Override
+  public boolean mayBeCost() {
+    return true;
+  }
+
+  @Override
   public String toString() {
     return "send " + (this.name == null ? "<top>" : this.name) + ", " + this.arity + ", "
         + this.unpackArgs + "      " + this.sourceInfo;

--- a/src/main/java/com/googlecode/aviator/exception/TimeoutException.java
+++ b/src/main/java/com/googlecode/aviator/exception/TimeoutException.java
@@ -4,7 +4,7 @@ package com.googlecode.aviator.exception;
  * The expression execution is timed out.
  *
  * @author dennis(killme2008@gmail.com)
- * @since 5.5.0
+ * @since 5.4.2
  */
 public class TimeoutException extends ExpressionRuntimeException {
 

--- a/src/main/java/com/googlecode/aviator/exception/TimeoutException.java
+++ b/src/main/java/com/googlecode/aviator/exception/TimeoutException.java
@@ -1,0 +1,29 @@
+package com.googlecode.aviator.exception;
+
+/**
+ * The expression execution is timed out.
+ *
+ * @author dennis(killme2008@gmail.com)
+ * @since 5.5.0
+ */
+public class TimeoutException extends ExpressionRuntimeException {
+
+  private static final long serialVersionUID = -3749680912179160158L;
+
+  public TimeoutException() {
+    super();
+  }
+
+  public TimeoutException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public TimeoutException(final String message) {
+    super(message);
+  }
+
+  public TimeoutException(final Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/src/main/java/com/googlecode/aviator/parser/ExpressionParser.java
+++ b/src/main/java/com/googlecode/aviator/parser/ExpressionParser.java
@@ -1602,8 +1602,7 @@ public class ExpressionParser implements Parser {
     if (expectChar('*')) {
       wildcard();
     } else {
-      checkVariableName(this.lookhead);
-      getCodeGenerator().onConstant(this.lookhead);
+      getCodeGenerator().onConstant(this.lookhead.withMeta(Constants.USE_CLASS_PKG, true));
     }
     move(true);
   }

--- a/src/main/java/com/googlecode/aviator/parser/ExpressionParser.java
+++ b/src/main/java/com/googlecode/aviator/parser/ExpressionParser.java
@@ -1602,6 +1602,7 @@ public class ExpressionParser implements Parser {
     if (expectChar('*')) {
       wildcard();
     } else {
+      checkVariableName(this.lookhead);
       getCodeGenerator().onConstant(this.lookhead.withMeta(Constants.USE_CLASS_PKG, true));
     }
     move(true);

--- a/src/main/java/com/googlecode/aviator/runtime/RuntimeUtils.java
+++ b/src/main/java/com/googlecode/aviator/runtime/RuntimeUtils.java
@@ -131,6 +131,11 @@ public final class RuntimeUtils {
     return getInstance(env).getOptionValue(Options.TRACE_EVAL).bool;
   }
 
+  // Returns the eval timeout value in milliseconds
+  public static final int getEvalTimeoutMs(final Map<String, Object> env) {
+    return getInstance(env).getOptionValue(Options.EVAL_TIMEOUT_MS).number;
+  }
+
   public static AviatorFunction getFunction(final Object object, final Map<String, Object> env) {
     if (object instanceof AviatorFunction) {
       return (AviatorFunction) object;

--- a/src/main/java/com/googlecode/aviator/runtime/RuntimeUtils.java
+++ b/src/main/java/com/googlecode/aviator/runtime/RuntimeUtils.java
@@ -3,9 +3,11 @@ package com.googlecode.aviator.runtime;
 import java.io.IOException;
 import java.math.MathContext;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import com.googlecode.aviator.AviatorEvaluator;
 import com.googlecode.aviator.AviatorEvaluatorInstance;
 import com.googlecode.aviator.Options;
+import com.googlecode.aviator.exception.TimeoutException;
 import com.googlecode.aviator.runtime.function.LambdaFunction;
 import com.googlecode.aviator.runtime.function.internal.UnpackingArgsFunction;
 import com.googlecode.aviator.runtime.type.AviatorFunction;
@@ -19,6 +21,7 @@ import com.googlecode.aviator.runtime.type.seq.IterableSequence;
 import com.googlecode.aviator.runtime.type.seq.LimitedSequence;
 import com.googlecode.aviator.runtime.type.seq.MapSequence;
 import com.googlecode.aviator.utils.Env;
+import com.googlecode.aviator.utils.Utils;
 
 /**
  * Runtime utils
@@ -101,6 +104,22 @@ public final class RuntimeUtils {
     return seq;
   }
 
+  public static void checkExecutionTimedOut(final Map<String, Object> env) {
+    long execTimeoutNs = getEvalTimeoutNs(env);
+    if (execTimeoutNs > 0) {
+      if (env instanceof Env) {
+        long startNs = ((Env) env).getStartNs();
+        if (startNs > 0) {
+          if (Utils.currentTimeNanos() - startNs > execTimeoutNs) {
+            throw new TimeoutException("Expression execution timed out, exceeded: "
+                + getInstance(env).getOptionValue(Options.EVAL_TIMEOUT_MS).number + " ms");
+          }
+        }
+      }
+    }
+
+  }
+
   /**
    * Ensure the object is not null, cast null into AviatorNil.
    *
@@ -131,9 +150,9 @@ public final class RuntimeUtils {
     return getInstance(env).getOptionValue(Options.TRACE_EVAL).bool;
   }
 
-  // Returns the eval timeout value in milliseconds
-  public static final int getEvalTimeoutMs(final Map<String, Object> env) {
-    return getInstance(env).getOptionValue(Options.EVAL_TIMEOUT_MS).number;
+  // Returns the eval timeout value in nanoseconds
+  public static final long getEvalTimeoutNs(final Map<String, Object> env) {
+    return getInstance(env).getOptionValue(Options.EVAL_TIMEOUT_MS).cachedNumber;
   }
 
   public static AviatorFunction getFunction(final Object object, final Map<String, Object> env) {

--- a/src/main/java/com/googlecode/aviator/runtime/RuntimeUtils.java
+++ b/src/main/java/com/googlecode/aviator/runtime/RuntimeUtils.java
@@ -105,11 +105,11 @@ public final class RuntimeUtils {
   }
 
   public static void checkExecutionTimedOut(final Map<String, Object> env) {
-    long execTimeoutNs = getEvalTimeoutNs(env);
-    if (execTimeoutNs > 0) {
-      if (env instanceof Env) {
-        long startNs = ((Env) env).getStartNs();
-        if (startNs > 0) {
+    if (env instanceof Env) {
+      long startNs = ((Env) env).getStartNs();
+      if (startNs > 0) {
+        long execTimeoutNs = getEvalTimeoutNs(env);
+        if (execTimeoutNs > 0) {
           if (Utils.currentTimeNanos() - startNs > execTimeoutNs) {
             throw new TimeoutException("Expression execution timed out, exceeded: "
                 + getInstance(env).getOptionValue(Options.EVAL_TIMEOUT_MS).number + " ms");

--- a/src/main/java/com/googlecode/aviator/runtime/function/LambdaFunction.java
+++ b/src/main/java/com/googlecode/aviator/runtime/function/LambdaFunction.java
@@ -241,9 +241,9 @@ public final class LambdaFunction extends AbstractVariadicFunction {
     Env env = null;
     if (!this.inheritEnv) {
       final Env contextEnv = new Env(parentEnv, this.context);
-      contextEnv.configure(this.context.getInstance(), this.expression);
+      contextEnv.configure(this.context.getInstance(), this.expression, this.context.getStartNs());
       env = new Env(contextEnv);
-      env.configure(this.context.getInstance(), this.expression);
+      env.configure(this.context.getInstance(), this.expression, this.context.getStartNs());
     } else {
       // assert (parentEnv == this.context);
       env = (Env) parentEnv;

--- a/src/main/java/com/googlecode/aviator/runtime/function/system/BigIntFunction.java
+++ b/src/main/java/com/googlecode/aviator/runtime/function/system/BigIntFunction.java
@@ -36,7 +36,9 @@ public class BigIntFunction extends AbstractFunction {
         } else if (obj instanceof Character) {
           return AviatorBigInt.valueOf(new BigInteger(String.valueOf(obj)));
         } else {
-          throw new ClassCastException("Could not cast " + (obj != null ? obj.getClass().getName() : "null")  + " to bigint, AviatorObject is " + arg1);
+          throw new ClassCastException(
+              "Could not cast " + (obj != null ? obj.getClass().getName() : "null")
+                  + " to bigint, AviatorObject is " + arg1);
         }
       case String:
         return AviatorBigInt.valueOf(new BigInteger((String) arg1.getValue(env)));

--- a/src/main/java/com/googlecode/aviator/runtime/function/system/DoubleFunction.java
+++ b/src/main/java/com/googlecode/aviator/runtime/function/system/DoubleFunction.java
@@ -34,7 +34,9 @@ public class DoubleFunction extends AbstractFunction {
         } else if (obj instanceof Character) {
           return new AviatorDouble(Double.parseDouble(String.valueOf(obj)));
         } else {
-          throw new ClassCastException("Could not cast " + (obj != null ? obj.getClass().getName() : "null")  + " to double, AviatorObject is" + arg1 );
+          throw new ClassCastException(
+              "Could not cast " + (obj != null ? obj.getClass().getName() : "null")
+                  + " to double, AviatorObject is" + arg1);
         }
       case String:
         return new AviatorDouble(Double.parseDouble((String) arg1.getValue(env)));

--- a/src/main/java/com/googlecode/aviator/runtime/function/system/LongFunction.java
+++ b/src/main/java/com/googlecode/aviator/runtime/function/system/LongFunction.java
@@ -34,7 +34,9 @@ public class LongFunction extends AbstractFunction {
         } else if (obj instanceof Character) {
           return AviatorLong.valueOf(Long.valueOf(String.valueOf(obj)));
         } else {
-          throw new ClassCastException("Could not cast " + (obj != null ? obj.getClass().getName() : "null")  + " to long, AviatorObject is " + arg1);
+          throw new ClassCastException(
+              "Could not cast " + (obj != null ? obj.getClass().getName() : "null")
+                  + " to long, AviatorObject is " + arg1);
         }
       case String:
         return AviatorLong.valueOf(Long.valueOf((String) arg1.getValue(env)));

--- a/src/main/java/com/googlecode/aviator/runtime/op/OperationRuntime.java
+++ b/src/main/java/com/googlecode/aviator/runtime/op/OperationRuntime.java
@@ -128,7 +128,6 @@ public class OperationRuntime {
    */
   public static AviatorObject eval(final AviatorObject left, final AviatorObject right,
       final Map<String, Object> env, final OperatorType opType) {
-
     AviatorFunction func = RuntimeUtils.getInstance(env).getOpFunction(opType);
     AviatorObject ret = eval0(left, right, env, opType, func);
     if (RuntimeUtils.isTracedEval(env)) {

--- a/src/main/java/com/googlecode/aviator/utils/Constants.java
+++ b/src/main/java/com/googlecode/aviator/utils/Constants.java
@@ -44,6 +44,7 @@ public class Constants {
   // Whether string has interpolation point.
   public static final String INTER_META = "hasInterpolation";
   public static final String UNPACK_ARGS = "unpackingArgs";
+  public static final String USE_CLASS_PKG = "useClassOrPkg";
   public static final Pattern SPLIT_PAT = Pattern.compile("\\.");
 
   // runtime metadata keys

--- a/src/main/java/com/googlecode/aviator/utils/Env.java
+++ b/src/main/java/com/googlecode/aviator/utils/Env.java
@@ -75,6 +75,9 @@ public class Env implements Map<String, Object>, Serializable {
 
   public static final Map<String, Object> EMPTY_ENV = Collections.emptyMap();
 
+  // The execution start timestamp in nanoseconds.
+  private long startNs = -1;
+
   /**
    * Constructs an env instance with empty state.
    */
@@ -98,6 +101,10 @@ public class Env implements Map<String, Object>, Serializable {
 
   public void setmOverrides(final Map<String, Object> mOverrides) {
     this.mOverrides = mOverrides;
+  }
+
+  public long getStartNs() {
+    return startNs;
   }
 
   public List<String> getImportedSymbols() {
@@ -148,9 +155,18 @@ public class Env implements Map<String, Object>, Serializable {
     this.instance = instance;
   }
 
-  public void configure(final AviatorEvaluatorInstance instance, final Expression exp) {
+  // Configure the env.
+  public void configure(final AviatorEvaluatorInstance instance, final Expression exp,
+      long startNs) {
     this.instance = instance;
     this.expression = exp;
+    setStartNs(startNs);
+  }
+
+  public void setStartNs(long startNs) {
+    if (this.startNs == -1) {
+      this.startNs = startNs;
+    }
   }
 
   private String findSymbol(final String name) throws ClassNotFoundException {

--- a/src/main/java/com/googlecode/aviator/utils/Env.java
+++ b/src/main/java/com/googlecode/aviator/utils/Env.java
@@ -33,7 +33,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import com.googlecode.aviator.AviatorEvaluatorInstance;
 import com.googlecode.aviator.Expression;
 import com.googlecode.aviator.Feature;
@@ -77,6 +76,7 @@ public class Env implements Map<String, Object>, Serializable {
 
   // The execution start timestamp in nanoseconds.
   private transient long startNs = -1;
+
 
   /**
    * Constructs an env instance with empty state.
@@ -163,8 +163,8 @@ public class Env implements Map<String, Object>, Serializable {
     setStartNs(startNs);
   }
 
-  public void setStartNs(long startNs) {
-    if (this.startNs == -1) {
+  private void setStartNs(long startNs) {
+    if (this.startNs == -1 && startNs > 0) {
       this.startNs = startNs;
     }
   }

--- a/src/main/java/com/googlecode/aviator/utils/Env.java
+++ b/src/main/java/com/googlecode/aviator/utils/Env.java
@@ -76,7 +76,7 @@ public class Env implements Map<String, Object>, Serializable {
   public static final Map<String, Object> EMPTY_ENV = Collections.emptyMap();
 
   // The execution start timestamp in nanoseconds.
-  private long startNs = -1;
+  private transient long startNs = -1;
 
   /**
    * Constructs an env instance with empty state.

--- a/src/main/java/com/googlecode/aviator/utils/Utils.java
+++ b/src/main/java/com/googlecode/aviator/utils/Utils.java
@@ -29,6 +29,10 @@ public class Utils {
 
   }
 
+  public static long currentTimeNanos() {
+    return System.nanoTime();
+  }
+
   private static final ThreadLocal<MessageDigest> MESSAGE_DIGEST_LOCAL =
       new ThreadLocal<MessageDigest>() {
 

--- a/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceCompatibleUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceCompatibleUnitTest.java
@@ -34,6 +34,11 @@ public class AviatorEvaluatorInstanceCompatibleUnitTest extends AviatorEvaluator
     // ignore
   }
 
+  @Test
+  public void testEvalTimeoutAndTryAgain() throws Exception {
+    // ignore
+  }
+
   @Override
   @Test
   public void testClassAllowList() {

--- a/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceCompatibleUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceCompatibleUnitTest.java
@@ -23,6 +23,11 @@ public class AviatorEvaluatorInstanceCompatibleUnitTest extends AviatorEvaluator
     super.testMaxLoopCount();
   }
 
+  @Test
+  public void testEvalTimeout() {
+    // ignore
+  }
+
   @Override
   @Test
   public void testIssue476() {

--- a/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceInterpreteUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceInterpreteUnitTest.java
@@ -2,7 +2,6 @@ package com.googlecode.aviator;
 
 import org.junit.Before;
 import org.junit.Test;
-import com.googlecode.aviator.exception.TimeoutException;
 
 public class AviatorEvaluatorInstanceInterpreteUnitTest extends AviatorEvaluatorInstanceUnitTest {
 
@@ -12,17 +11,10 @@ public class AviatorEvaluatorInstanceInterpreteUnitTest extends AviatorEvaluator
   public void setup() {
     super.setup();
     this.instance.setOption(Options.EVAL_MODE, EvalMode.INTERPRETER);
-    this.instance.setOption(Options.EVAL_TIMEOUT_MS, 50);
   }
 
   @Test
   public void testTraceEval() throws Exception {
     // ignore
   }
-
-  @Test(expected = TimeoutException.class)
-  public void testEvalTimeout() {
-    this.instance.execute("while(true) { }");
-  }
-
 }

--- a/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceInterpreteUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceInterpreteUnitTest.java
@@ -12,6 +12,7 @@ public class AviatorEvaluatorInstanceInterpreteUnitTest extends AviatorEvaluator
   public void setup() {
     super.setup();
     this.instance.setOption(Options.EVAL_MODE, EvalMode.INTERPRETER);
+    this.instance.setOption(Options.EVAL_TIMEOUT_MS, 50);
   }
 
   @Test
@@ -21,8 +22,6 @@ public class AviatorEvaluatorInstanceInterpreteUnitTest extends AviatorEvaluator
 
   @Test(expected = TimeoutException.class)
   public void testEvalTimeout() {
-    this.instance.setOption(Options.EVAL_TIMEOUT_MS, 1);
-
     this.instance.execute("while(true) { }");
   }
 

--- a/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceInterpreteUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceInterpreteUnitTest.java
@@ -1,0 +1,29 @@
+package com.googlecode.aviator;
+
+import org.junit.Before;
+import org.junit.Test;
+import com.googlecode.aviator.exception.TimeoutException;
+
+public class AviatorEvaluatorInstanceInterpreteUnitTest extends AviatorEvaluatorInstanceUnitTest {
+
+
+  @Override
+  @Before
+  public void setup() {
+    super.setup();
+    this.instance.setOption(Options.EVAL_MODE, EvalMode.INTERPRETER);
+  }
+
+  @Test
+  public void testTraceEval() throws Exception {
+    // ignore
+  }
+
+  @Test(expected = TimeoutException.class)
+  public void testEvalTimeout() {
+    this.instance.setOption(Options.EVAL_TIMEOUT_MS, 1);
+
+    this.instance.execute("while(true) { }");
+  }
+
+}

--- a/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceUnitTest.java
@@ -680,7 +680,6 @@ public class AviatorEvaluatorInstanceUnitTest {
       this.instance.setOption(Options.TRACE_EVAL, false);
       this.instance.setTraceOutputStream(System.out);
     }
-
   }
 
   @Test(expected = CompileExpressionErrorException.class)

--- a/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceUnitTest.java
@@ -74,6 +74,21 @@ public class AviatorEvaluatorInstanceUnitTest {
     this.instance.execute("while(true) { }");
   }
 
+  @Test
+  public void testEvalTimeoutAndTryAgain() throws Exception {
+    Expression exp = this.instance.compile("Thread.sleep(120); a + 1");
+    try {
+      exp.execute(exp.newEnv("a", 2));
+    } catch (TimeoutException e) {
+      assertTrue(e.getMessage().contains("Expression execution timed out, exceeded: 100 ms"));
+      // ignore
+    }
+    this.instance.setOption(Options.EVAL_TIMEOUT_MS, 200);
+    assertEquals(exp.execute(exp.newEnv("a", 2)), 3);
+    Thread.sleep(500);
+    assertEquals(exp.execute(exp.newEnv("a", 2)), 3);
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void testIssue466() {

--- a/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/AviatorEvaluatorInstanceUnitTest.java
@@ -38,6 +38,7 @@ import com.googlecode.aviator.AviatorEvaluatorInstance.StringSegments;
 import com.googlecode.aviator.exception.CompileExpressionErrorException;
 import com.googlecode.aviator.exception.ExpressionRuntimeException;
 import com.googlecode.aviator.exception.ExpressionSyntaxErrorException;
+import com.googlecode.aviator.exception.TimeoutException;
 import com.googlecode.aviator.exception.UnsupportedFeatureException;
 import com.googlecode.aviator.lexer.token.OperatorType;
 import com.googlecode.aviator.runtime.function.AbstractFunction;
@@ -57,6 +58,7 @@ public class AviatorEvaluatorInstanceUnitTest {
   @Before
   public void setup() {
     this.instance = AviatorEvaluator.newInstance();
+    this.instance.setOption(Options.EVAL_TIMEOUT_MS, 100);
   }
 
   @Test
@@ -65,6 +67,11 @@ public class AviatorEvaluatorInstanceUnitTest {
     assertTrue(expr.getVariableFullNames().isEmpty());
     expr = instance.compile("let abc = new String('abc'); abc + x");
     assertEquals(expr.getVariableFullNames(), Arrays.asList("x"));
+  }
+
+  @Test(expected = TimeoutException.class)
+  public void testEvalTimeout() {
+    this.instance.execute("while(true) { }");
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/com/googlecode/aviator/AviatorEvaluatorUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/AviatorEvaluatorUnitTest.java
@@ -42,6 +42,13 @@ public class AviatorEvaluatorUnitTest {
     assertEquals(4, exp2.execute(null));
   }
 
+  @Test
+  public void testIssue597() {
+    String s = "use java.lang.Thread;\n" + "Thread.sleep(2000);\n" + "return 1 > 0;";
+
+    Expression exp = AviatorEvaluator.compile(s);
+    assertTrue(exp.getVariableNames().isEmpty());
+  }
 
   @Test
   public void testNewEnv() {

--- a/src/test/java/com/googlecode/aviator/runtime/function/system/BigIntFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/system/BigIntFunctionUnitTest.java
@@ -2,26 +2,25 @@ package com.googlecode.aviator.runtime.function.system;
 
 import com.googlecode.aviator.runtime.type.AviatorJavaType;
 import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
 
 
 public class BigIntFunctionUnitTest {
-    @Test(expected = ClassCastException.class)
-    public void testCall_WithJavaTypeNullArgument() {
-        BigIntFunction bigIntFunction = new BigIntFunction();
-        AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
-        bigIntFunction.call(null, aviatorJavaType);
-    }
+  @Test(expected = ClassCastException.class)
+  public void testCall_WithJavaTypeNullArgument() {
+    BigIntFunction bigIntFunction = new BigIntFunction();
+    AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
+    bigIntFunction.call(null, aviatorJavaType);
+  }
 
-    @Test(expected = ClassCastException.class)
-    public void testCall_WithJavaTypeNotSupportArgument() {
-        BigIntFunction bigIntFunction = new BigIntFunction();
-        AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
-        Map<String, Object> env = new HashMap<>();
-        env.put("var", true);
+  @Test(expected = ClassCastException.class)
+  public void testCall_WithJavaTypeNotSupportArgument() {
+    BigIntFunction bigIntFunction = new BigIntFunction();
+    AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
+    Map<String, Object> env = new HashMap<>();
+    env.put("var", true);
 
-        bigIntFunction.call(env, aviatorJavaType);
-    }
+    bigIntFunction.call(env, aviatorJavaType);
+  }
 }

--- a/src/test/java/com/googlecode/aviator/runtime/function/system/DoubleFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/system/DoubleFunctionUnitTest.java
@@ -2,26 +2,25 @@ package com.googlecode.aviator.runtime.function.system;
 
 import com.googlecode.aviator.runtime.type.AviatorJavaType;
 import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
 
 
 public class DoubleFunctionUnitTest {
-    @Test(expected = ClassCastException.class)
-    public void testCall_WithJavaTypeNullArgument() {
-        DoubleFunction doubleFunction = new DoubleFunction();
-        AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
-        doubleFunction.call(null, aviatorJavaType);
-    }
+  @Test(expected = ClassCastException.class)
+  public void testCall_WithJavaTypeNullArgument() {
+    DoubleFunction doubleFunction = new DoubleFunction();
+    AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
+    doubleFunction.call(null, aviatorJavaType);
+  }
 
-    @Test(expected = ClassCastException.class)
-    public void testCall_WithJavaTypeNotSupportArgument() {
-        DoubleFunction doubleFunction = new DoubleFunction();
-        AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
-        Map<String, Object> env = new HashMap<>();
-        env.put("var", true);
+  @Test(expected = ClassCastException.class)
+  public void testCall_WithJavaTypeNotSupportArgument() {
+    DoubleFunction doubleFunction = new DoubleFunction();
+    AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
+    Map<String, Object> env = new HashMap<>();
+    env.put("var", true);
 
-        doubleFunction.call(env, aviatorJavaType);
-    }
+    doubleFunction.call(env, aviatorJavaType);
+  }
 }

--- a/src/test/java/com/googlecode/aviator/runtime/function/system/LongFunctionUnitTest.java
+++ b/src/test/java/com/googlecode/aviator/runtime/function/system/LongFunctionUnitTest.java
@@ -2,26 +2,25 @@ package com.googlecode.aviator.runtime.function.system;
 
 import com.googlecode.aviator.runtime.type.AviatorJavaType;
 import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
 
 
 public class LongFunctionUnitTest {
-    @Test(expected = ClassCastException.class)
-    public void testCall_WithJavaTypeNullArgument() {
-        LongFunction longFunction = new LongFunction();
-        AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
-        longFunction.call(null, aviatorJavaType);
-    }
+  @Test(expected = ClassCastException.class)
+  public void testCall_WithJavaTypeNullArgument() {
+    LongFunction longFunction = new LongFunction();
+    AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
+    longFunction.call(null, aviatorJavaType);
+  }
 
-    @Test(expected = ClassCastException.class)
-    public void testCall_WithJavaTypeNotSupportArgument() {
-        LongFunction longFunction = new LongFunction();
-        AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
-        Map<String, Object> env = new HashMap<>();
-        env.put("var", true);
+  @Test(expected = ClassCastException.class)
+  public void testCall_WithJavaTypeNotSupportArgument() {
+    LongFunction longFunction = new LongFunction();
+    AviatorJavaType aviatorJavaType = new AviatorJavaType("var");
+    Map<String, Object> env = new HashMap<>();
+    env.put("var", true);
 
-        longFunction.call(env, aviatorJavaType);
-    }
+    longFunction.call(env, aviatorJavaType);
+  }
 }


### PR DESCRIPTION
* Supports execution timeout by `Options.EVAL_TIMEOUT_MS` option, close #628 
* Fixed returning wrong results in `Expression#getVariableFullNames` #597 
* Upgrade the compile JDK version to 1.8