### PR TITLE
refactor: replace typo lookhead with lookahead

### DIFF
--- a/examples/calculator.av
+++ b/examples/calculator.av
@@ -69,7 +69,7 @@ fn expr(parser, tokens) {
   term(parser, tokens);
 
   while true {
-    let t = parser.lookhead;
+    let t = parser.lookahead;
 
     if t.val == '+' {
       parser.move();
@@ -89,7 +89,7 @@ fn term(parser, tokens) {
   unary(parser, tokens);
 
   while true {
-    let t = parser.lookhead;
+    let t = parser.lookahead;
 
     if t.val == '*' {
       parser.move();
@@ -106,7 +106,7 @@ fn term(parser, tokens) {
 }
 
 fn unary(parser, tokens) {
-  let t = parser.lookhead;
+  let t = parser.lookahead;
   if t.val == '-' {
     parser.move();
     unary(parser, tokens);
@@ -117,12 +117,12 @@ fn unary(parser, tokens) {
 }
 
 fn factor(parser, tokens) {
-  let t = parser.lookhead;
+  let t = parser.lookahead;
 
   if t.val == '(' {
     parser.move();
     expr(parser, tokens);
-    t = parser.lookhead;
+    t = parser.lookahead;
     if t.val != ')'{
       error(t);
     }
@@ -137,10 +137,10 @@ fn factor(parser, tokens) {
 
 fn parser(lexer) {
   let parser = seq.map();
-  parser.lookhead = lexer();
+  parser.lookahead = lexer();
 
   parser.move = fn() {
-    parser.lookhead = lexer();
+    parser.lookahead = lexer();
   };
 
   return parser;
@@ -153,8 +153,8 @@ fn parse(s) {
 
   expr(parser, tokens);
 
-  if parser.lookhead.type != EOF {
-    error(parser.lookhead);
+  if parser.lookahead.type != EOF {
+    error(parser.lookahead);
   }
 
   return tokens;

--- a/src/main/java/com/googlecode/aviator/AviatorEvaluatorInstance.java
+++ b/src/main/java/com/googlecode/aviator/AviatorEvaluatorInstance.java
@@ -1828,12 +1828,12 @@ public final class AviatorEvaluatorInstance {
                   new ExpressionParser(this, lexer, newCodeGenerator(sourceFile, false));
 
               Expression exp = parser.parse(false);
-              final Token<?> lookhead = parser.getLookhead();
-              if (lookhead == null || (lookhead.getType() != TokenType.Char
-                  || ((CharToken) lookhead).getCh() != '}')) {
+              final Token<?> lookahead = parser.getLookahead();
+              if (lookahead == null || (lookahead.getType() != TokenType.Char
+                  || ((CharToken) lookahead).getCh() != '}')) {
                 parser.reportSyntaxError("expect '}' to complete string interpolation");
               }
-              int expStrLen = lookhead.getStartIndex() + 1;
+              int expStrLen = lookahead.getStartIndex() + 1;
               while (expStrLen-- > 0) {
                 prev = ch;
                 ch = it.next();

--- a/src/main/java/com/googlecode/aviator/code/CodeGenerator.java
+++ b/src/main/java/com/googlecode/aviator/code/CodeGenerator.java
@@ -29,118 +29,118 @@ import com.googlecode.aviator.runtime.FunctionParam;
  */
 public interface CodeGenerator {
 
-  public void onAssignment(Token<?> lookhead);
+  public void onAssignment(Token<?> lookahead);
 
   public void setParser(Parser parser);
 
-  public void onShiftRight(Token<?> lookhead);
+  public void onShiftRight(Token<?> lookahead);
 
 
-  public void onShiftLeft(Token<?> lookhead);
+  public void onShiftLeft(Token<?> lookahead);
 
 
-  public void onUnsignedShiftRight(Token<?> lookhead);
+  public void onUnsignedShiftRight(Token<?> lookahead);
 
 
-  public void onBitOr(Token<?> lookhead);
+  public void onBitOr(Token<?> lookahead);
 
 
-  public void onBitAnd(Token<?> lookhead);
+  public void onBitAnd(Token<?> lookahead);
 
 
-  public void onBitXor(Token<?> lookhead);
+  public void onBitXor(Token<?> lookahead);
 
 
-  public void onBitNot(Token<?> lookhead);
+  public void onBitNot(Token<?> lookahead);
 
 
-  public void onAdd(Token<?> lookhead);
+  public void onAdd(Token<?> lookahead);
 
 
-  public void onSub(Token<?> lookhead);
+  public void onSub(Token<?> lookahead);
 
 
-  public void onMult(Token<?> lookhead);
+  public void onMult(Token<?> lookahead);
 
   public void onExponent(Token<?> loohead);
 
 
-  public void onDiv(Token<?> lookhead);
+  public void onDiv(Token<?> lookahead);
 
 
-  public void onAndLeft(Token<?> lookhead);
+  public void onAndLeft(Token<?> lookahead);
 
 
-  public void onAndRight(Token<?> lookhead);
+  public void onAndRight(Token<?> alookahead);
 
 
-  public void onTernaryBoolean(Token<?> lookhead);
+  public void onTernaryBoolean(Token<?> lookahead);
 
 
-  public void onTernaryLeft(Token<?> lookhead);
+  public void onTernaryLeft(Token<?> lookahead);
 
 
-  public void onTernaryRight(Token<?> lookhead);
+  public void onTernaryRight(Token<?> lookahead);
 
-  public void onTernaryEnd(Token<?> lookhead);
-
-
-  public void onJoinLeft(Token<?> lookhead);
+  public void onTernaryEnd(Token<?> lookahead);
 
 
-  public void onJoinRight(Token<?> lookhead);
+  public void onJoinLeft(Token<?> lookahead);
 
 
-  public void onEq(Token<?> lookhead);
+  public void onJoinRight(Token<?> lookahead);
 
 
-  public void onMatch(Token<?> lookhead);
+  public void onEq(Token<?> lookahead);
 
 
-  public void onNeq(Token<?> lookhead);
+  public void onMatch(Token<?> lookahead);
 
 
-  public void onLt(Token<?> lookhead);
+  public void onNeq(Token<?> lookahead);
 
 
-  public void onLe(Token<?> lookhead);
+  public void onLt(Token<?> lookahead);
 
 
-  public void onGt(Token<?> lookhead);
+  public void onLe(Token<?> lookahead);
 
 
-  public void onGe(Token<?> lookhead);
+  public void onGt(Token<?> lookahead);
 
 
-  public void onMod(Token<?> lookhead);
+  public void onGe(Token<?> lookahead);
 
 
-  public void onNot(Token<?> lookhead);
+  public void onMod(Token<?> lookahead);
 
 
-  public void onNeg(Token<?> lookhead);
+  public void onNot(Token<?> lookahead);
+
+
+  public void onNeg(Token<?> lookahead);
 
   public Expression getResult(boolean unboxObject);
 
-  public void onConstant(Token<?> lookhead);
+  public void onConstant(Token<?> lookahead);
 
-  public void onMethodName(Token<?> lookhead);
+  public void onMethodName(Token<?> lookahead);
 
-  public void onMethodParameter(Token<?> lookhead);
+  public void onMethodParameter(Token<?> lookahead);
 
-  public void onMethodInvoke(Token<?> lookhead);
+  public void onMethodInvoke(Token<?> lookahead);
 
-  public void onLambdaDefineStart(Token<?> lookhead);
+  public void onLambdaDefineStart(Token<?> lookahead);
 
-  public void onLambdaArgument(Token<?> lookhead, FunctionParam param);
+  public void onLambdaArgument(Token<?> lookahead, FunctionParam param);
 
-  public void onLambdaBodyStart(Token<?> lookhead);
+  public void onLambdaBodyStart(Token<?> lookahead);
 
-  public void onLambdaBodyEnd(Token<?> lookhead);
+  public void onLambdaBodyEnd(Token<?> lookahead);
 
-  public void onArray(Token<?> lookhead);
+  public void onArray(Token<?> lookahead);
 
   public void onArrayIndexStart(Token<?> token);
 
-  public void onArrayIndexEnd(Token<?> lookhead);
+  public void onArrayIndexEnd(Token<?> lookahead);
 }

--- a/src/main/java/com/googlecode/aviator/code/LambdaGenerator.java
+++ b/src/main/java/com/googlecode/aviator/code/LambdaGenerator.java
@@ -210,212 +210,212 @@ public class LambdaGenerator implements CodeGenerator {
 
 
   @Override
-  public void onShiftRight(final Token<?> lookhead) {
-    this.codeGenerator.onShiftRight(lookhead);
+  public void onShiftRight(final Token<?> lookahead) {
+    this.codeGenerator.onShiftRight(lookahead);
   }
 
 
 
   @Override
-  public void onShiftLeft(final Token<?> lookhead) {
-    this.codeGenerator.onShiftLeft(lookhead);
+  public void onShiftLeft(final Token<?> lookahead) {
+    this.codeGenerator.onShiftLeft(lookahead);
   }
 
 
 
   @Override
-  public void onUnsignedShiftRight(final Token<?> lookhead) {
-    this.codeGenerator.onUnsignedShiftRight(lookhead);
+  public void onUnsignedShiftRight(final Token<?> lookahead) {
+    this.codeGenerator.onUnsignedShiftRight(lookahead);
   }
 
 
 
   @Override
-  public void onAssignment(final Token<?> lookhead) {
-    this.codeGenerator.onAssignment(lookhead);
+  public void onAssignment(final Token<?> lookahead) {
+    this.codeGenerator.onAssignment(lookahead);
   }
 
 
   @Override
-  public void onBitOr(final Token<?> lookhead) {
-    this.codeGenerator.onBitOr(lookhead);
+  public void onBitOr(final Token<?> lookahead) {
+    this.codeGenerator.onBitOr(lookahead);
   }
 
 
   @Override
-  public void onBitAnd(final Token<?> lookhead) {
-    this.codeGenerator.onBitAnd(lookhead);
-  }
-
-
-
-  @Override
-  public void onBitXor(final Token<?> lookhead) {
-    this.codeGenerator.onBitXor(lookhead);
+  public void onBitAnd(final Token<?> lookahead) {
+    this.codeGenerator.onBitAnd(lookahead);
   }
 
 
 
   @Override
-  public void onBitNot(final Token<?> lookhead) {
-    this.codeGenerator.onBitNot(lookhead);
+  public void onBitXor(final Token<?> lookahead) {
+    this.codeGenerator.onBitXor(lookahead);
   }
 
 
 
   @Override
-  public void onAdd(final Token<?> lookhead) {
-    this.codeGenerator.onAdd(lookhead);
-  }
-
-  @Override
-  public void onSub(final Token<?> lookhead) {
-    this.codeGenerator.onSub(lookhead);
+  public void onBitNot(final Token<?> lookahead) {
+    this.codeGenerator.onBitNot(lookahead);
   }
 
 
 
   @Override
-  public void onMult(final Token<?> lookhead) {
-    this.codeGenerator.onMult(lookhead);
+  public void onAdd(final Token<?> lookahead) {
+    this.codeGenerator.onAdd(lookahead);
+  }
+
+  @Override
+  public void onSub(final Token<?> lookahead) {
+    this.codeGenerator.onSub(lookahead);
   }
 
 
 
   @Override
-  public void onExponent(final Token<?> lookhead) {
-    this.codeGenerator.onExponent(lookhead);
-  }
-
-
-  @Override
-  public void onDiv(final Token<?> lookhead) {
-    this.codeGenerator.onDiv(lookhead);
+  public void onMult(final Token<?> lookahead) {
+    this.codeGenerator.onMult(lookahead);
   }
 
 
 
   @Override
-  public void onAndLeft(final Token<?> lookhead) {
-    this.codeGenerator.onAndLeft(lookhead);
+  public void onExponent(final Token<?> lookahead) {
+    this.codeGenerator.onExponent(lookahead);
+  }
+
+
+  @Override
+  public void onDiv(final Token<?> lookahead) {
+    this.codeGenerator.onDiv(lookahead);
   }
 
 
 
   @Override
-  public void onAndRight(final Token<?> lookhead) {
-    this.codeGenerator.onAndRight(lookhead);
+  public void onAndLeft(final Token<?> lookahead) {
+    this.codeGenerator.onAndLeft(lookahead);
   }
 
 
 
   @Override
-  public void onTernaryBoolean(final Token<?> lookhead) {
-    this.codeGenerator.onTernaryBoolean(lookhead);
+  public void onAndRight(final Token<?> alookahead) {
+    this.codeGenerator.onAndRight(alookahead);
   }
 
 
 
   @Override
-  public void onTernaryLeft(final Token<?> lookhead) {
-    this.codeGenerator.onTernaryLeft(lookhead);
+  public void onTernaryBoolean(final Token<?> lookahead) {
+    this.codeGenerator.onTernaryBoolean(lookahead);
   }
 
 
 
   @Override
-  public void onTernaryRight(final Token<?> lookhead) {
-    this.codeGenerator.onTernaryRight(lookhead);
+  public void onTernaryLeft(final Token<?> lookahead) {
+    this.codeGenerator.onTernaryLeft(lookahead);
   }
 
 
 
   @Override
-  public void onTernaryEnd(final Token<?> lookhead) {
-    this.codeGenerator.onTernaryEnd(lookhead);
-  }
-
-
-  @Override
-  public void onJoinLeft(final Token<?> lookhead) {
-    this.codeGenerator.onJoinLeft(lookhead);
+  public void onTernaryRight(final Token<?> lookahead) {
+    this.codeGenerator.onTernaryRight(lookahead);
   }
 
 
 
   @Override
-  public void onJoinRight(final Token<?> lookhead) {
-    this.codeGenerator.onJoinRight(lookhead);
+  public void onTernaryEnd(final Token<?> lookahead) {
+    this.codeGenerator.onTernaryEnd(lookahead);
+  }
+
+
+  @Override
+  public void onJoinLeft(final Token<?> lookahead) {
+    this.codeGenerator.onJoinLeft(lookahead);
   }
 
 
 
   @Override
-  public void onEq(final Token<?> lookhead) {
-    this.codeGenerator.onEq(lookhead);
+  public void onJoinRight(final Token<?> lookahead) {
+    this.codeGenerator.onJoinRight(lookahead);
   }
 
 
 
   @Override
-  public void onMatch(final Token<?> lookhead) {
-    this.codeGenerator.onMatch(lookhead);
+  public void onEq(final Token<?> lookahead) {
+    this.codeGenerator.onEq(lookahead);
   }
 
 
 
   @Override
-  public void onNeq(final Token<?> lookhead) {
-    this.codeGenerator.onNeq(lookhead);
+  public void onMatch(final Token<?> lookahead) {
+    this.codeGenerator.onMatch(lookahead);
   }
 
 
 
   @Override
-  public void onLt(final Token<?> lookhead) {
-    this.codeGenerator.onLt(lookhead);
+  public void onNeq(final Token<?> lookahead) {
+    this.codeGenerator.onNeq(lookahead);
   }
 
 
 
   @Override
-  public void onLe(final Token<?> lookhead) {
-    this.codeGenerator.onLe(lookhead);
+  public void onLt(final Token<?> lookahead) {
+    this.codeGenerator.onLt(lookahead);
   }
 
 
 
   @Override
-  public void onGt(final Token<?> lookhead) {
-    this.codeGenerator.onGt(lookhead);
+  public void onLe(final Token<?> lookahead) {
+    this.codeGenerator.onLe(lookahead);
   }
 
 
 
   @Override
-  public void onGe(final Token<?> lookhead) {
-    this.codeGenerator.onGe(lookhead);
+  public void onGt(final Token<?> lookahead) {
+    this.codeGenerator.onGt(lookahead);
   }
 
 
 
   @Override
-  public void onMod(final Token<?> lookhead) {
-    this.codeGenerator.onMod(lookhead);
+  public void onGe(final Token<?> lookahead) {
+    this.codeGenerator.onGe(lookahead);
   }
 
 
 
   @Override
-  public void onNot(final Token<?> lookhead) {
-    this.codeGenerator.onNot(lookhead);
+  public void onMod(final Token<?> lookahead) {
+    this.codeGenerator.onMod(lookahead);
   }
 
 
 
   @Override
-  public void onNeg(final Token<?> lookhead) {
-    this.codeGenerator.onNeg(lookhead);
+  public void onNot(final Token<?> lookahead) {
+    this.codeGenerator.onNot(lookahead);
+  }
+
+
+
+  @Override
+  public void onNeg(final Token<?> lookahead) {
+    this.codeGenerator.onNeg(lookahead);
   }
 
 
@@ -426,55 +426,55 @@ public class LambdaGenerator implements CodeGenerator {
 
 
   @Override
-  public void onConstant(final Token<?> lookhead) {
-    this.codeGenerator.onConstant(lookhead);
+  public void onConstant(final Token<?> lookahead) {
+    this.codeGenerator.onConstant(lookahead);
   }
 
   @Override
-  public void onMethodName(final Token<?> lookhead) {
-    this.codeGenerator.onMethodName(lookhead);
-  }
-
-
-
-  @Override
-  public void onMethodParameter(final Token<?> lookhead) {
-    this.codeGenerator.onMethodParameter(lookhead);
-  }
-
-  @Override
-  public void onMethodInvoke(final Token<?> lookhead) {
-    this.codeGenerator.onMethodInvoke(lookhead);
+  public void onMethodName(final Token<?> lookahead) {
+    this.codeGenerator.onMethodName(lookahead);
   }
 
 
 
   @Override
-  public void onLambdaDefineStart(final Token<?> lookhead) {
-    this.codeGenerator.onLambdaDefineStart(lookhead);
+  public void onMethodParameter(final Token<?> lookahead) {
+    this.codeGenerator.onMethodParameter(lookahead);
+  }
+
+  @Override
+  public void onMethodInvoke(final Token<?> lookahead) {
+    this.codeGenerator.onMethodInvoke(lookahead);
   }
 
 
 
   @Override
-  public void onLambdaArgument(final Token<?> lookhead, final FunctionParam param) {
-    this.codeGenerator.onLambdaArgument(lookhead, param);
+  public void onLambdaDefineStart(final Token<?> lookahead) {
+    this.codeGenerator.onLambdaDefineStart(lookahead);
+  }
+
+
+
+  @Override
+  public void onLambdaArgument(final Token<?> lookahead, final FunctionParam param) {
+    this.codeGenerator.onLambdaArgument(lookahead, param);
   }
 
   @Override
-  public void onLambdaBodyStart(final Token<?> lookhead) {
-    this.codeGenerator.onLambdaBodyStart(lookhead);
+  public void onLambdaBodyStart(final Token<?> lookahead) {
+    this.codeGenerator.onLambdaBodyStart(lookahead);
   }
 
   @Override
-  public void onLambdaBodyEnd(final Token<?> lookhead) {
+  public void onLambdaBodyEnd(final Token<?> lookahead) {
     // should call parent generator
-    this.parentCodeGenerator.onLambdaBodyEnd(lookhead);
+    this.parentCodeGenerator.onLambdaBodyEnd(lookahead);
   }
 
   @Override
-  public void onArray(final Token<?> lookhead) {
-    this.codeGenerator.onArray(lookhead);
+  public void onArray(final Token<?> lookahead) {
+    this.codeGenerator.onArray(lookahead);
   }
 
   @Override
@@ -483,8 +483,8 @@ public class LambdaGenerator implements CodeGenerator {
   }
 
   @Override
-  public void onArrayIndexEnd(final Token<?> lookhead) {
-    this.codeGenerator.onArrayIndexEnd(lookhead);
+  public void onArrayIndexEnd(final Token<?> lookahead) {
+    this.codeGenerator.onArrayIndexEnd(lookahead);
   }
 
 }

--- a/src/main/java/com/googlecode/aviator/code/NoneCodeGenerator.java
+++ b/src/main/java/com/googlecode/aviator/code/NoneCodeGenerator.java
@@ -20,7 +20,7 @@ public class NoneCodeGenerator implements CodeGenerator {
   private Parser parser;
 
   @Override
-  public void onAssignment(final Token<?> lookhead) {
+  public void onAssignment(final Token<?> lookahead) {
 
 
   }
@@ -31,61 +31,61 @@ public class NoneCodeGenerator implements CodeGenerator {
   }
 
   @Override
-  public void onShiftRight(final Token<?> lookhead) {
+  public void onShiftRight(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onShiftLeft(final Token<?> lookhead) {
+  public void onShiftLeft(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onUnsignedShiftRight(final Token<?> lookhead) {
+  public void onUnsignedShiftRight(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onBitOr(final Token<?> lookhead) {
+  public void onBitOr(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onBitAnd(final Token<?> lookhead) {
+  public void onBitAnd(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onBitXor(final Token<?> lookhead) {
+  public void onBitXor(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onBitNot(final Token<?> lookhead) {
+  public void onBitNot(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onAdd(final Token<?> lookhead) {
+  public void onAdd(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onSub(final Token<?> lookhead) {
+  public void onSub(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onMult(final Token<?> lookhead) {
+  public void onMult(final Token<?> lookahead) {
 
 
   }
@@ -93,120 +93,120 @@ public class NoneCodeGenerator implements CodeGenerator {
 
 
   @Override
-  public void onExponent(final Token<?> lookhead) {
+  public void onExponent(final Token<?> lookahead) {
 
   }
 
   @Override
-  public void onDiv(final Token<?> lookhead) {
-
-
-  }
-
-  @Override
-  public void onAndLeft(final Token<?> lookhead) {
+  public void onDiv(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onAndRight(final Token<?> lookhead) {
+  public void onAndLeft(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onTernaryBoolean(final Token<?> lookhead) {
+  public void onAndRight(final Token<?> alookahead) {
 
 
   }
 
   @Override
-  public void onTernaryLeft(final Token<?> lookhead) {
+  public void onTernaryBoolean(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onTernaryRight(final Token<?> lookhead) {
+  public void onTernaryLeft(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onTernaryEnd(final Token<?> lookhead) {
+  public void onTernaryRight(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onJoinLeft(final Token<?> lookhead) {
+  public void onTernaryEnd(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onJoinRight(final Token<?> lookhead) {
+  public void onJoinLeft(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onEq(final Token<?> lookhead) {
+  public void onJoinRight(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onMatch(final Token<?> lookhead) {
+  public void onEq(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onNeq(final Token<?> lookhead) {
+  public void onMatch(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onLt(final Token<?> lookhead) {
+  public void onNeq(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onLe(final Token<?> lookhead) {
+  public void onLt(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onGt(final Token<?> lookhead) {
+  public void onLe(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onGe(final Token<?> lookhead) {
+  public void onGt(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onMod(final Token<?> lookhead) {
+  public void onGe(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onNot(final Token<?> lookhead) {
+  public void onMod(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onNeg(final Token<?> lookhead) {
+  public void onNot(final Token<?> lookahead) {
+
+
+  }
+
+  @Override
+  public void onNeg(final Token<?> lookahead) {
 
 
   }
@@ -218,54 +218,54 @@ public class NoneCodeGenerator implements CodeGenerator {
   }
 
   @Override
-  public void onConstant(final Token<?> lookhead) {
+  public void onConstant(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onMethodName(final Token<?> lookhead) {
+  public void onMethodName(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onMethodParameter(final Token<?> lookhead) {
+  public void onMethodParameter(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onMethodInvoke(final Token<?> lookhead) {
+  public void onMethodInvoke(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onLambdaDefineStart(final Token<?> lookhead) {
-    Boolean newLexicalScope = lookhead.getMeta(Constants.SCOPE_META, false);
+  public void onLambdaDefineStart(final Token<?> lookahead) {
+    Boolean newLexicalScope = lookahead.getMeta(Constants.SCOPE_META, false);
     this.infos.push(this.parser.enterScope(newLexicalScope));
   }
 
   @Override
-  public void onLambdaArgument(final Token<?> lookhead, final FunctionParam param) {
+  public void onLambdaArgument(final Token<?> lookahead, final FunctionParam param) {
 
 
   }
 
   @Override
-  public void onLambdaBodyStart(final Token<?> lookhead) {
+  public void onLambdaBodyStart(final Token<?> lookahead) {
 
 
   }
 
   @Override
-  public void onLambdaBodyEnd(final Token<?> lookhead) {
+  public void onLambdaBodyEnd(final Token<?> lookahead) {
     this.parser.restoreScope(this.infos.pop());
   }
 
   @Override
-  public void onArray(final Token<?> lookhead) {
+  public void onArray(final Token<?> lookahead) {
 
 
   }
@@ -277,7 +277,7 @@ public class NoneCodeGenerator implements CodeGenerator {
   }
 
   @Override
-  public void onArrayIndexEnd(final Token<?> lookhead) {
+  public void onArrayIndexEnd(final Token<?> lookahead) {
 
 
   }

--- a/src/main/java/com/googlecode/aviator/code/OptimizeCodeGenerator.java
+++ b/src/main/java/com/googlecode/aviator/code/OptimizeCodeGenerator.java
@@ -319,36 +319,36 @@ public class OptimizeCodeGenerator implements CodeGenerator {
   }
 
 
-  private AviatorObject getAviatorObjectFromToken(final Token<?> lookhead) {
+  private AviatorObject getAviatorObjectFromToken(final Token<?> lookahead) {
     AviatorObject result = null;
-    switch (lookhead.getType()) {
+    switch (lookahead.getType()) {
       case Number:
         // load numbers
-        NumberToken numberToken = (NumberToken) lookhead;
+        NumberToken numberToken = (NumberToken) lookahead;
         Number num = numberToken.getNumber();
         result = AviatorNumber.valueOf(num);
         break;
       case String:
         // load string
         result =
-            new AviatorString((String) lookhead.getValue(null), true, true, lookhead.getLineNo());
+            new AviatorString((String) lookahead.getValue(null), true, true, lookahead.getLineNo());
         break;
       case Pattern:
         // load pattern
-        result = new AviatorPattern((String) lookhead.getValue(null));
+        result = new AviatorPattern((String) lookahead.getValue(null));
         break;
       case Variable:
-        if (lookhead == Variable.TRUE) {
+        if (lookahead == Variable.TRUE) {
           result = AviatorBoolean.TRUE;
-        } else if (lookhead == Variable.FALSE) {
+        } else if (lookahead == Variable.FALSE) {
           result = AviatorBoolean.FALSE;
-        } else if (lookhead == Variable.NIL) {
+        } else if (lookahead == Variable.NIL) {
           result = AviatorNil.NIL;
         }
         break;
       case Char:
-        result = new AviatorString(String.valueOf(lookhead.getValue(null)), true, true,
-            lookhead.getLineNo());
+        result = new AviatorString(String.valueOf(lookahead.getValue(null)), true, true,
+            lookahead.getLineNo());
         break;
     }
     return result;
@@ -617,151 +617,151 @@ public class OptimizeCodeGenerator implements CodeGenerator {
 
 
   @Override
-  public void onAdd(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.ADD));
+  public void onAdd(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.ADD));
 
   }
 
 
   @Override
-  public void onAndLeft(final Token<?> lookhead) {
-    this.tokenList.add(new DelegateToken(lookhead, DelegateTokenType.And_Left));
+  public void onAndLeft(final Token<?> lookahead) {
+    this.tokenList.add(new DelegateToken(lookahead, DelegateTokenType.And_Left));
   }
 
 
   @Override
-  public void onAndRight(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.AND));
-
-  }
-
-
-  @Override
-  public void onConstant(final Token<?> lookhead) {
-    this.tokenList.add(lookhead);
-  }
-
-
-  @Override
-  public void onDiv(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.DIV));
+  public void onAndRight(final Token<?> alookahead) {
+    this.tokenList.add(new OperatorToken(alookahead, OperatorType.AND));
 
   }
 
 
   @Override
-  public void onArrayIndexStart(final Token<?> lookhead) {
-    this.tokenList.add(new DelegateToken(lookhead, DelegateTokenType.Index_Start));
+  public void onConstant(final Token<?> lookahead) {
+    this.tokenList.add(lookahead);
+  }
+
+
+  @Override
+  public void onDiv(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.DIV));
+
+  }
+
+
+  @Override
+  public void onArrayIndexStart(final Token<?> lookahead) {
+    this.tokenList.add(new DelegateToken(lookahead, DelegateTokenType.Index_Start));
 
   }
 
   @Override
-  public void onAssignment(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead,
-        (lookhead == null || !lookhead.getMeta(Constants.DEFINE_META, false))
+  public void onAssignment(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead,
+        (lookahead == null || !lookahead.getMeta(Constants.DEFINE_META, false))
             ? OperatorType.ASSIGNMENT
             : OperatorType.DEFINE));
   }
 
 
   @Override
-  public void onArrayIndexEnd(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.INDEX));
+  public void onArrayIndexEnd(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.INDEX));
   }
 
 
   @Override
-  public void onArray(final Token<?> lookhead) {
-    this.tokenList.add(new DelegateToken(lookhead, DelegateTokenType.Array));
-
-  }
-
-
-  @Override
-  public void onEq(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.EQ));
+  public void onArray(final Token<?> lookahead) {
+    this.tokenList.add(new DelegateToken(lookahead, DelegateTokenType.Array));
 
   }
 
 
   @Override
-  public void onGe(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.GE));
+  public void onEq(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.EQ));
 
   }
 
 
   @Override
-  public void onGt(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.GT));
+  public void onGe(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.GE));
 
   }
 
 
   @Override
-  public void onJoinLeft(final Token<?> lookhead) {
-    this.tokenList.add(new DelegateToken(lookhead, DelegateTokenType.Join_Left));
-  }
-
-
-  @Override
-  public void onJoinRight(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.OR));
+  public void onGt(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.GT));
 
   }
 
 
   @Override
-  public void onLe(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.LE));
+  public void onJoinLeft(final Token<?> lookahead) {
+    this.tokenList.add(new DelegateToken(lookahead, DelegateTokenType.Join_Left));
+  }
+
+
+  @Override
+  public void onJoinRight(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.OR));
 
   }
 
 
   @Override
-  public void onLt(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.LT));
+  public void onLe(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.LE));
 
   }
 
 
   @Override
-  public void onMatch(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.MATCH));
+  public void onLt(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.LT));
 
   }
 
 
   @Override
-  public void onMethodInvoke(final Token<?> lookhead) {
-    OperatorToken token = new OperatorToken(lookhead, OperatorType.FUNC);
-    token.setMetaMap(lookhead != null ? lookhead.getMetaMap() : null);
+  public void onMatch(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.MATCH));
+
+  }
+
+
+  @Override
+  public void onMethodInvoke(final Token<?> lookahead) {
+    OperatorToken token = new OperatorToken(lookahead, OperatorType.FUNC);
+    token.setMetaMap(lookahead != null ? lookahead.getMetaMap() : null);
     this.tokenList.add(token);
 
   }
 
 
   @Override
-  public void onMethodName(final Token<?> lookhead) {
-    this.tokenList.add(new DelegateToken(lookhead, DelegateTokenType.Method_Name));
+  public void onMethodName(final Token<?> lookahead) {
+    this.tokenList.add(new DelegateToken(lookahead, DelegateTokenType.Method_Name));
 
   }
 
 
   @Override
-  public void onMethodParameter(final Token<?> lookhead) {
-    this.tokenList.add(new DelegateToken(lookhead, DelegateTokenType.Method_Param));
+  public void onMethodParameter(final Token<?> lookahead) {
+    this.tokenList.add(new DelegateToken(lookahead, DelegateTokenType.Method_Param));
 
   }
 
 
 
   @Override
-  public void onLambdaDefineStart(final Token<?> lookhead) {
+  public void onLambdaDefineStart(final Token<?> lookahead) {
     if (this.lambdaGenerator == null) {
       // TODO cache?
-      Boolean newLexicalScope = lookhead.getMeta(Constants.SCOPE_META, false);
-      Boolean inheritEnv = lookhead.getMeta(Constants.INHERIT_ENV_META, false);
+      Boolean newLexicalScope = lookahead.getMeta(Constants.SCOPE_META, false);
+      Boolean inheritEnv = lookahead.getMeta(Constants.INHERIT_ENV_META, false);
       this.lambdaGenerator = new LambdaGenerator(this.instance, this, this.parser,
           this.codeGen.getClassLoader(), this.sourceFile, newLexicalScope, inheritEnv);
       this.lambdaGenerator.setScopeInfo(this.parser.enterScope(newLexicalScope));
@@ -772,27 +772,27 @@ public class OptimizeCodeGenerator implements CodeGenerator {
 
 
   @Override
-  public void onLambdaArgument(final Token<?> lookhead, final FunctionParam param) {
+  public void onLambdaArgument(final Token<?> lookahead, final FunctionParam param) {
     this.lambdaGenerator.addParam(param);
   }
 
 
   @Override
-  public void onLambdaBodyStart(final Token<?> lookhead) {
+  public void onLambdaBodyStart(final Token<?> lookahead) {
     this.parentCodeGenerator = this.parser.getCodeGenerator();
     this.parser.setCodeGenerator(this.lambdaGenerator);
   }
 
 
   @Override
-  public void onLambdaBodyEnd(final Token<?> lookhead) {
+  public void onLambdaBodyEnd(final Token<?> lookahead) {
     // this.lambdaGenerator.compileCallMethod();
     LambdaFunctionBootstrap bootstrap = this.lambdaGenerator.getLmabdaBootstrap();
     if (this.lambdaBootstraps == null) {
       this.lambdaBootstraps = new HashMap<String, LambdaFunctionBootstrap>();
     }
     this.lambdaBootstraps.put(bootstrap.getName(), bootstrap);
-    DelegateToken token = new DelegateToken(lookhead, DelegateTokenType.Lambda_New);
+    DelegateToken token = new DelegateToken(lookahead, DelegateTokenType.Lambda_New);
     token.setLambdaFunctionBootstrap(bootstrap);
     this.tokenList.add(token);
     this.parser.restoreScope(this.lambdaGenerator.getScopeInfo());
@@ -802,122 +802,122 @@ public class OptimizeCodeGenerator implements CodeGenerator {
 
 
   @Override
-  public void onMod(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.MOD));
+  public void onMod(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.MOD));
 
   }
 
 
   @Override
-  public void onMult(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.MULT));
+  public void onMult(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.MULT));
 
   }
 
   @Override
-  public void onExponent(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.Exponent));
+  public void onExponent(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.Exponent));
 
   }
 
   @Override
-  public void onNeg(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.NEG));
-
-  }
-
-
-  @Override
-  public void onNeq(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.NEQ));
+  public void onNeg(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.NEG));
 
   }
 
 
   @Override
-  public void onNot(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.NOT));
+  public void onNeq(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.NEQ));
 
   }
 
 
   @Override
-  public void onSub(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.SUB));
+  public void onNot(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.NOT));
 
   }
 
 
   @Override
-  public void onTernaryBoolean(final Token<?> lookhead) {
-    this.tokenList.add(new DelegateToken(lookhead, DelegateTokenType.Ternary_Boolean));
+  public void onSub(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.SUB));
 
   }
 
 
   @Override
-  public void onTernaryLeft(final Token<?> lookhead) {
-    this.tokenList.add(new DelegateToken(lookhead, DelegateTokenType.Ternary_Left));
+  public void onTernaryBoolean(final Token<?> lookahead) {
+    this.tokenList.add(new DelegateToken(lookahead, DelegateTokenType.Ternary_Boolean));
 
   }
 
 
   @Override
-  public void onTernaryRight(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.TERNARY));
-  }
-
-
-  @Override
-  public void onTernaryEnd(final Token<?> lookhead) {
-    this.tokenList.add(new DelegateToken(lookhead, DelegateTokenType.Ternay_End));
-  }
-
-
-  @Override
-  public void onBitAnd(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.BIT_AND));
+  public void onTernaryLeft(final Token<?> lookahead) {
+    this.tokenList.add(new DelegateToken(lookahead, DelegateTokenType.Ternary_Left));
 
   }
 
 
   @Override
-  public void onBitNot(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.BIT_NOT));
+  public void onTernaryRight(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.TERNARY));
   }
 
 
   @Override
-  public void onBitOr(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.BIT_OR));
-
+  public void onTernaryEnd(final Token<?> lookahead) {
+    this.tokenList.add(new DelegateToken(lookahead, DelegateTokenType.Ternay_End));
   }
 
 
   @Override
-  public void onShiftLeft(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.SHIFT_LEFT));
-
-  }
-
-
-  @Override
-  public void onShiftRight(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.SHIFT_RIGHT));
+  public void onBitAnd(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.BIT_AND));
 
   }
 
 
   @Override
-  public void onUnsignedShiftRight(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.U_SHIFT_RIGHT));
+  public void onBitNot(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.BIT_NOT));
+  }
+
+
+  @Override
+  public void onBitOr(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.BIT_OR));
 
   }
 
 
   @Override
-  public void onBitXor(final Token<?> lookhead) {
-    this.tokenList.add(new OperatorToken(lookhead, OperatorType.BIT_XOR));
+  public void onShiftLeft(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.SHIFT_LEFT));
+
+  }
+
+
+  @Override
+  public void onShiftRight(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.SHIFT_RIGHT));
+
+  }
+
+
+  @Override
+  public void onUnsignedShiftRight(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.U_SHIFT_RIGHT));
+
+  }
+
+
+  @Override
+  public void onBitXor(final Token<?> lookahead) {
+    this.tokenList.add(new OperatorToken(lookahead, OperatorType.BIT_XOR));
 
   }
 

--- a/src/main/java/com/googlecode/aviator/code/asm/ASMCodeGenerator.java
+++ b/src/main/java/com/googlecode/aviator/code/asm/ASMCodeGenerator.java
@@ -292,8 +292,8 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * @see com.googlecode.aviator.code.CodeGenerator#onAdd(com.googlecode.aviator .lexer.token.Token)
    */
   @Override
-  public void onAdd(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.ADD, "add");
+  public void onAdd(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.ADD, "add");
   }
 
   private void loadOpType(final OperatorType opType) {
@@ -322,8 +322,8 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * @see com.googlecode.aviator.code.CodeGenerator#onSub(com.googlecode.aviator .lexer.token.Token)
    */
   @Override
-  public void onSub(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.SUB, "sub");
+  public void onSub(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.SUB, "sub");
   }
 
   /*
@@ -333,19 +333,19 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * .lexer.token.Token)
    */
   @Override
-  public void onMult(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.MULT, "mult");
+  public void onMult(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.MULT, "mult");
   }
 
   @Override
-  public void onExponent(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.Exponent, "exponent");
+  public void onExponent(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.Exponent, "exponent");
   }
 
   @Override
-  public void onAssignment(final Token<?> lookhead) {
-    visitLineNumber(lookhead);
-    OperatorType opType = lookhead.getMeta(Constants.DEFINE_META, false) ? OperatorType.DEFINE
+  public void onAssignment(final Token<?> lookahead) {
+    visitLineNumber(lookahead);
+    OperatorType opType = lookahead.getMeta(Constants.DEFINE_META, false) ? OperatorType.DEFINE
         : OperatorType.ASSIGNMENT;
     loadEnv();
     if (!OperationRuntime.hasRuntimeContext(this.compileEnv, opType)) {
@@ -369,8 +369,8 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * @see com.googlecode.aviator.code.CodeGenerator#onDiv(com.googlecode.aviator .lexer.token.Token)
    */
   @Override
-  public void onDiv(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.DIV, "div");
+  public void onDiv(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.DIV, "div");
   }
 
   /*
@@ -379,17 +379,17 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * @see com.googlecode.aviator.code.CodeGenerator#onMod(com.googlecode.aviator .lexer.token.Token)
    */
   @Override
-  public void onMod(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.MOD, "mod");
+  public void onMod(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.MOD, "mod");
   }
 
   /**
    * Do logic operation "&&" left operand
    */
   @Override
-  public void onAndLeft(final Token<?> lookhead) {
+  public void onAndLeft(final Token<?> lookahead) {
     loadEnv();
-    visitLeftBranch(lookhead, IFEQ, OperatorType.AND);
+    visitLeftBranch(lookahead, IFEQ, OperatorType.AND);
   }
 
   private void visitBoolean() {
@@ -404,13 +404,13 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * Do logic operation "&&" right operand
    */
   @Override
-  public void onAndRight(final Token<?> lookhead) {
-    visitRightBranch(lookhead, IFEQ, OperatorType.AND);
+  public void onAndRight(final Token<?> lookahead) {
+    visitRightBranch(lookahead, IFEQ, OperatorType.AND);
     this.popOperand(2); // boolean object and environment
     this.pushOperand();
   }
 
-  private void visitRightBranch(final Token<?> lookhead, final int ints,
+  private void visitRightBranch(final Token<?> lookahead, final int ints,
       final OperatorType opType) {
     this.checkExecutionTimeout();
     if (!OperationRuntime.hasRuntimeContext(this.compileEnv, opType)) {
@@ -425,7 +425,7 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
       this.mv.visitInsn(POP);
 
       Label l1 = makeLabel();
-      visitLineNumber(lookhead);
+      visitLineNumber(lookahead);
       this.mv.visitJumpInsn(GOTO, l1);
       visitLabel(popLabel0());
       // Result is false
@@ -434,7 +434,7 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
       visitLabel(l1);
     } else {
       loadOpType(opType);
-      visitLineNumber(lookhead);
+      visitLineNumber(lookahead);
       this.mv.visitMethodInsn(INVOKESTATIC, "com/googlecode/aviator/runtime/op/OperationRuntime",
           "eval",
           "(Lcom/googlecode/aviator/runtime/type/AviatorObject;Ljava/util/Map;Lcom/googlecode/aviator/runtime/type/AviatorObject;Lcom/googlecode/aviator/lexer/token/OperatorType;)Lcom/googlecode/aviator/runtime/type/AviatorObject;");
@@ -449,9 +449,9 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   private final Stack<Label> l1stack = new Stack<Label>();
 
   @Override
-  public void onTernaryBoolean(final Token<?> lookhead) {
+  public void onTernaryBoolean(final Token<?> lookahead) {
     loadEnv();
-    visitLineNumber(lookhead);
+    visitLineNumber(lookahead);
     checkExecutionTimeout();
     visitBoolean();
     Label l0 = makeLabel();
@@ -471,11 +471,11 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onTernaryLeft(final Token<?> lookhead) {
+  public void onTernaryLeft(final Token<?> lookahead) {
     checkExecutionTimeout();
     this.mv.visitJumpInsn(GOTO, peekLabel1());
     visitLabel(popLabel0());
-    visitLineNumber(lookhead);
+    visitLineNumber(lookahead);
     this.popOperand(); // pop one boolean
   }
 
@@ -484,16 +484,16 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onTernaryRight(final Token<?> lookhead) {
+  public void onTernaryRight(final Token<?> lookahead) {
     checkExecutionTimeout();
     visitLabel(popLabel1());
-    visitLineNumber(lookhead);
+    visitLineNumber(lookahead);
     this.popOperand(); // pop one boolean
   }
 
   @Override
-  public void onTernaryEnd(final Token<?> lookhead) {
-    visitLineNumber(lookhead);
+  public void onTernaryEnd(final Token<?> lookahead) {
+    visitLineNumber(lookahead);
     if (this.operandsCount == 0) {
       return;
     }
@@ -510,8 +510,8 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * Do logic operation "||" right operand
    */
   @Override
-  public void onJoinRight(final Token<?> lookhead) {
-    visitRightBranch(lookhead, IFNE, OperatorType.OR);
+  public void onJoinRight(final Token<?> lookahead) {
+    visitRightBranch(lookahead, IFNE, OperatorType.OR);
     this.popOperand(2);
     this.pushOperand();
 
@@ -534,18 +534,18 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * Do logic operation "||" left operand
    */
   @Override
-  public void onJoinLeft(final Token<?> lookhead) {
+  public void onJoinLeft(final Token<?> lookahead) {
     loadEnv();
-    visitLeftBranch(lookhead, IFNE, OperatorType.OR);
+    visitLeftBranch(lookahead, IFNE, OperatorType.OR);
   }
 
-  private void visitLeftBranch(final Token<?> lookhead, final int ints, final OperatorType opType) {
+  private void visitLeftBranch(final Token<?> lookahead, final int ints, final OperatorType opType) {
     this.checkExecutionTimeout();
     if (!OperationRuntime.hasRuntimeContext(this.compileEnv, opType)) {
       visitBoolean();
       Label l0 = makeLabel();
       pushLabel0(l0);
-      visitLineNumber(lookhead);
+      visitLineNumber(lookahead);
       this.mv.visitJumpInsn(ints, l0);
       this.popOperand();
     }
@@ -553,26 +553,26 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onEq(final Token<?> lookhead) {
-    doCompareAndJump(lookhead, IFNE, OperatorType.EQ);
+  public void onEq(final Token<?> lookahead) {
+    doCompareAndJump(lookahead, IFNE, OperatorType.EQ);
   }
 
   @Override
-  public void onMatch(final Token<?> lookhead) {
-    visitLineNumber(lookhead);
-    visitBinOperator(lookhead, OperatorType.MATCH, "match");
+  public void onMatch(final Token<?> lookahead) {
+    visitLineNumber(lookahead);
+    visitBinOperator(lookahead, OperatorType.MATCH, "match");
     this.popOperand();
     this.pushOperand();
   }
 
   @Override
-  public void onNeq(final Token<?> lookhead) {
-    doCompareAndJump(lookhead, IFEQ, OperatorType.NEQ);
+  public void onNeq(final Token<?> lookahead) {
+    doCompareAndJump(lookahead, IFEQ, OperatorType.NEQ);
   }
 
-  private void doCompareAndJump(final Token<?> lookhead, final int ints,
+  private void doCompareAndJump(final Token<?> lookahead, final int ints,
       final OperatorType opType) {
-    visitLineNumber(lookhead);
+    visitLineNumber(lookahead);
     this.checkExecutionTimeout();
     loadEnv();
     visitCompare(ints, opType);
@@ -609,24 +609,24 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onGe(final Token<?> lookhead) {
-    doCompareAndJump(lookhead, IFLT, OperatorType.GE);
+  public void onGe(final Token<?> lookahead) {
+    doCompareAndJump(lookahead, IFLT, OperatorType.GE);
   }
 
   @Override
-  public void onGt(final Token<?> lookhead) {
-    doCompareAndJump(lookhead, IFLE, OperatorType.GT);
+  public void onGt(final Token<?> lookahead) {
+    doCompareAndJump(lookahead, IFLE, OperatorType.GT);
   }
 
   @Override
-  public void onLe(final Token<?> lookhead) {
-    doCompareAndJump(lookhead, IFGT, OperatorType.LE);
+  public void onLe(final Token<?> lookahead) {
+    doCompareAndJump(lookahead, IFGT, OperatorType.LE);
 
   }
 
   @Override
-  public void onLt(final Token<?> lookhead) {
-    doCompareAndJump(lookhead, IFGE, OperatorType.LT);
+  public void onLt(final Token<?> lookahead) {
+    doCompareAndJump(lookahead, IFGE, OperatorType.LT);
   }
 
   private void pushOperand(final int delta) {
@@ -638,8 +638,8 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * Logic operation '!'
    */
   @Override
-  public void onNot(final Token<?> lookhead) {
-    visitUnaryOperator(lookhead, OperatorType.NOT, "not");
+  public void onNot(final Token<?> lookahead) {
+    visitUnaryOperator(lookahead, OperatorType.NOT, "not");
   }
 
   private void visitBinOperator(final Token<?> token, final OperatorType opType,
@@ -672,9 +672,9 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
     }
   }
 
-  private void visitUnaryOperator(final Token<?> lookhead, final OperatorType opType,
+  private void visitUnaryOperator(final Token<?> lookahead, final OperatorType opType,
       final String methodName) {
-    visitLineNumber(lookhead);
+    visitLineNumber(lookahead);
     this.mv.visitTypeInsn(CHECKCAST, OBJECT_OWNER);
     loadEnv();
 
@@ -696,8 +696,8 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * Bit operation '~'
    */
   @Override
-  public void onBitNot(final Token<?> lookhead) {
-    visitUnaryOperator(lookhead, OperatorType.BIT_NOT, "bitNot");
+  public void onBitNot(final Token<?> lookahead) {
+    visitUnaryOperator(lookahead, OperatorType.BIT_NOT, "bitNot");
   }
 
   /*
@@ -707,8 +707,8 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * int)
    */
   @Override
-  public void onNeg(final Token<?> lookhead) {
-    visitUnaryOperator(lookhead, OperatorType.NEG, "neg");
+  public void onNeg(final Token<?> lookahead) {
+    visitUnaryOperator(lookahead, OperatorType.NEG, "neg");
   }
 
   /*
@@ -855,24 +855,24 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
    * .lexer.token.Token)
    */
   @Override
-  public void onConstant(final Token<?> lookhead) {
-    onConstant0(lookhead, false);
+  public void onConstant(final Token<?> lookahead) {
+    onConstant0(lookahead, false);
   }
 
-  private void onConstant0(final Token<?> lookhead, final boolean inConstructor) {
-    if (lookhead == null) {
+  private void onConstant0(final Token<?> lookahead, final boolean inConstructor) {
+    if (lookahead == null) {
       return;
     }
-    visitLineNumber(lookhead);
+    visitLineNumber(lookahead);
     // load token to stack
-    switch (lookhead.getType()) {
+    switch (lookahead.getType()) {
       case Number:
-        if (loadConstant(lookhead, inConstructor)) {
+        if (loadConstant(lookahead, inConstructor)) {
           return;
         }
 
         // load numbers
-        NumberToken numberToken = (NumberToken) lookhead;
+        NumberToken numberToken = (NumberToken) lookahead;
         Number number = numberToken.getNumber();
 
         if (TypeUtils.isBigInt(number)) {
@@ -907,29 +907,29 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
         // this.popOperand();
         break;
       case String:
-        if (loadConstant(lookhead, inConstructor)) {
+        if (loadConstant(lookahead, inConstructor)) {
           return;
         }
         // load string
         this.mv.visitTypeInsn(NEW, "com/googlecode/aviator/runtime/type/AviatorString");
         this.mv.visitInsn(DUP);
-        this.mv.visitLdcInsn(lookhead.getValue(null));
+        this.mv.visitLdcInsn(lookahead.getValue(null));
         this.mv.visitLdcInsn(true);
-        this.mv.visitLdcInsn(lookhead.getMeta(Constants.INTER_META, true));
-        this.mv.visitLdcInsn(lookhead.getLineNo());
+        this.mv.visitLdcInsn(lookahead.getMeta(Constants.INTER_META, true));
+        this.mv.visitLdcInsn(lookahead.getLineNo());
         this.mv.visitMethodInsn(INVOKESPECIAL, "com/googlecode/aviator/runtime/type/AviatorString",
             CONSTRUCTOR_METHOD_NAME, "(Ljava/lang/String;ZZI)V");
         this.pushOperand(6);
         this.popOperand(5);
         break;
       case Pattern:
-        if (loadConstant(lookhead, inConstructor)) {
+        if (loadConstant(lookahead, inConstructor)) {
           return;
         }
         // load pattern
         this.mv.visitTypeInsn(NEW, "com/googlecode/aviator/runtime/type/AviatorPattern");
         this.mv.visitInsn(DUP);
-        this.mv.visitLdcInsn(lookhead.getValue(null));
+        this.mv.visitLdcInsn(lookahead.getValue(null));
         this.mv.visitMethodInsn(INVOKESPECIAL, "com/googlecode/aviator/runtime/type/AviatorPattern",
             CONSTRUCTOR_METHOD_NAME, "(Ljava/lang/String;)V");
         this.pushOperand(3);
@@ -937,7 +937,7 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
         break;
       case Variable:
         // load variable
-        Variable variable = (Variable) lookhead;
+        Variable variable = (Variable) lookahead;
 
         if (variable.equals(Variable.TRUE)) {
           this.mv.visitFieldInsn(GETSTATIC, "com/googlecode/aviator/runtime/type/AviatorBoolean",
@@ -999,9 +999,9 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
     }
   }
 
-  private boolean loadConstant(final Token<?> lookhead, final boolean inConstructor) {
+  private boolean loadConstant(final Token<?> lookahead, final boolean inConstructor) {
     String fieldName;
-    if (!inConstructor && (fieldName = this.constantPool.get(lookhead)) != null) {
+    if (!inConstructor && (fieldName = this.constantPool.get(lookahead)) != null) {
       this.mv.visitVarInsn(ALOAD, 0);
       this.mv.visitFieldInsn(GETFIELD, this.className, fieldName, OBJECT_DESC);
       this.pushOperand();
@@ -1081,11 +1081,11 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onMethodInvoke(final Token<?> lookhead) {
-    visitLineNumber(lookhead);
+  public void onMethodInvoke(final Token<?> lookahead) {
+    visitLineNumber(lookahead);
     @SuppressWarnings("unchecked")
-    final List<FunctionArgument> params = lookhead != null
-        ? (List<FunctionArgument>) lookhead.getMeta(Constants.PARAMS_META, Collections.EMPTY_LIST)
+    final List<FunctionArgument> params = lookahead != null
+        ? (List<FunctionArgument>) lookahead.getMeta(Constants.PARAMS_META, Collections.EMPTY_LIST)
         : Collections.EMPTY_LIST;
 
     if (this.instance.getOptionValue(Options.CAPTURE_FUNCTION_ARGS).bool) {
@@ -1149,8 +1149,8 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onMethodParameter(final Token<?> lookhead) {
-    visitLineNumber(lookhead);
+  public void onMethodParameter(final Token<?> lookahead) {
+    visitLineNumber(lookahead);
     MethodMetaData currentMethodMetaData = this.methodMetaDataStack.peek();
     if (currentMethodMetaData.parameterCount >= 20) {
       // Add last param to variadic param list
@@ -1209,8 +1209,8 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onArray(final Token<?> lookhead) {
-    onConstant(lookhead);
+  public void onArray(final Token<?> lookahead) {
+    onConstant(lookahead);
   }
 
   @Override
@@ -1219,8 +1219,8 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onArrayIndexEnd(final Token<?> lookhead) {
-    visitLineNumber(lookhead);
+  public void onArrayIndexEnd(final Token<?> lookahead) {
+    visitLineNumber(lookahead);
     if (!OperationRuntime.hasRuntimeContext(this.compileEnv, OperatorType.INDEX)) {
       this.mv.visitMethodInsn(INVOKEVIRTUAL, OBJECT_OWNER, "getElement",
           "(Ljava/util/Map;Lcom/googlecode/aviator/runtime/type/AviatorObject;)Lcom/googlecode/aviator/runtime/type/AviatorObject;");
@@ -1241,10 +1241,10 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onLambdaDefineStart(final Token<?> lookhead) {
+  public void onLambdaDefineStart(final Token<?> lookahead) {
     if (this.lambdaGenerator == null) {
-      Boolean newLexicalScope = lookhead.getMeta(Constants.SCOPE_META, false);
-      Boolean inheritEnv = lookhead.getMeta(Constants.INHERIT_ENV_META, false);
+      Boolean newLexicalScope = lookahead.getMeta(Constants.SCOPE_META, false);
+      Boolean inheritEnv = lookahead.getMeta(Constants.INHERIT_ENV_META, false);
       // TODO cache?
       this.lambdaGenerator = new LambdaGenerator(this.instance, this, this.parser, this.classLoader,
           this.sourceFile, newLexicalScope, inheritEnv);
@@ -1255,18 +1255,18 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onLambdaArgument(final Token<?> lookhead, final FunctionParam param) {
+  public void onLambdaArgument(final Token<?> lookahead, final FunctionParam param) {
     this.lambdaGenerator.addParam(param);
   }
 
   @Override
-  public void onLambdaBodyStart(final Token<?> lookhead) {
+  public void onLambdaBodyStart(final Token<?> lookahead) {
     this.parentCodeGenerator = this.parser.getCodeGenerator();
     this.parser.setCodeGenerator(this.lambdaGenerator);
   }
 
   @Override
-  public void onLambdaBodyEnd(final Token<?> lookhead) {
+  public void onLambdaBodyEnd(final Token<?> lookahead) {
     // this.lambdaGenerator.compileCallMethod();
     LambdaFunctionBootstrap bootstrap = this.lambdaGenerator.getLmabdaBootstrap();
     if (this.lambdaBootstraps == null) {
@@ -1274,7 +1274,7 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
       this.lambdaBootstraps = new LinkedHashMap<String, LambdaFunctionBootstrap>();
     }
     this.lambdaBootstraps.put(bootstrap.getName(), bootstrap);
-    visitLineNumber(lookhead);
+    visitLineNumber(lookahead);
     genNewLambdaCode(bootstrap);
     this.parser.restoreScope(this.lambdaGenerator.getScopeInfo());
     this.lambdaGenerator = null;
@@ -1293,13 +1293,13 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onMethodName(final Token<?> lookhead) {
+  public void onMethodName(final Token<?> lookahead) {
 
     checkExecutionTimeout();
 
     String outtterMethodName = "lambda";
-    if (lookhead.getType() != TokenType.Delegate) {
-      outtterMethodName = lookhead.getLexeme();
+    if (lookahead.getType() != TokenType.Delegate) {
+      outtterMethodName = lookahead.getLexeme();
       String innerMethodName = this.innerMethodMap.get(outtterMethodName);
       if (innerMethodName != null) {
         loadAviatorFunction(outtterMethodName, innerMethodName);
@@ -1318,13 +1318,13 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
           "(Lcom/googlecode/aviator/runtime/type/AviatorFunction;)Lcom/googlecode/aviator/runtime/type/AviatorFunction;");
     }
     // FIXME it will not work in compile mode.
-    if (lookhead.getMeta(Constants.UNPACK_ARGS, false)) {
+    if (lookahead.getMeta(Constants.UNPACK_ARGS, false)) {
       this.mv.visitMethodInsn(INVOKESTATIC, RUNTIME_UTILS, "unpackArgsFunction",
           "(Lcom/googlecode/aviator/runtime/type/AviatorFunction;)Lcom/googlecode/aviator/runtime/type/AviatorFunction;");
     }
 
     loadEnv();
-    this.methodMetaDataStack.push(new MethodMetaData(lookhead, outtterMethodName));
+    this.methodMetaDataStack.push(new MethodMetaData(lookahead, outtterMethodName));
   }
 
   private void checkExecutionTimeout() {
@@ -1380,35 +1380,35 @@ public class ASMCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onBitAnd(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.BIT_AND, "bitAnd");
+  public void onBitAnd(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.BIT_AND, "bitAnd");
   }
 
   @Override
-  public void onBitOr(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.BIT_OR, "bitOr");
+  public void onBitOr(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.BIT_OR, "bitOr");
   }
 
   @Override
-  public void onBitXor(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.BIT_XOR, "bitXor");
+  public void onBitXor(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.BIT_XOR, "bitXor");
   }
 
   @Override
-  public void onShiftLeft(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.SHIFT_LEFT, "shiftLeft");
-
-  }
-
-  @Override
-  public void onShiftRight(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.SHIFT_RIGHT, "shiftRight");
+  public void onShiftLeft(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.SHIFT_LEFT, "shiftLeft");
 
   }
 
   @Override
-  public void onUnsignedShiftRight(final Token<?> lookhead) {
-    visitBinOperator(lookhead, OperatorType.U_SHIFT_RIGHT, "unsignedShiftRight");
+  public void onShiftRight(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.SHIFT_RIGHT, "shiftRight");
+
+  }
+
+  @Override
+  public void onUnsignedShiftRight(final Token<?> lookahead) {
+    visitBinOperator(lookahead, OperatorType.U_SHIFT_RIGHT, "unsignedShiftRight");
 
   }
 

--- a/src/main/java/com/googlecode/aviator/code/interpreter/InterpretCodeGenerator.java
+++ b/src/main/java/com/googlecode/aviator/code/interpreter/InterpretCodeGenerator.java
@@ -129,8 +129,8 @@ public class InterpretCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onAssignment(final Token<?> lookhead) {
-    if (lookhead.getMeta(Constants.DEFINE_META, false)) {
+  public void onAssignment(final Token<?> lookahead) {
+    if (lookahead.getMeta(Constants.DEFINE_META, false)) {
       emit(OperatorIR.DEF);
     } else {
       emit(OperatorIR.ASSIGN);
@@ -138,53 +138,53 @@ public class InterpretCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onShiftRight(final Token<?> lookhead) {
+  public void onShiftRight(final Token<?> lookahead) {
     emit(OperatorIR.SHIFT_RIGHT);
   }
 
   @Override
-  public void onShiftLeft(final Token<?> lookhead) {
+  public void onShiftLeft(final Token<?> lookahead) {
     emit(OperatorIR.SHIFT_LEFT);
   }
 
   @Override
-  public void onUnsignedShiftRight(final Token<?> lookhead) {
+  public void onUnsignedShiftRight(final Token<?> lookahead) {
     emit(OperatorIR.UNSIGNED_SHIFT_RIGHT);
   }
 
   @Override
-  public void onBitOr(final Token<?> lookhead) {
+  public void onBitOr(final Token<?> lookahead) {
     emit(OperatorIR.BIT_OR);
   }
 
   @Override
-  public void onBitAnd(final Token<?> lookhead) {
+  public void onBitAnd(final Token<?> lookahead) {
     emit(OperatorIR.BIT_AND);
   }
 
   @Override
-  public void onBitXor(final Token<?> lookhead) {
+  public void onBitXor(final Token<?> lookahead) {
     emit(OperatorIR.BIT_XOR);
   }
 
   @Override
-  public void onBitNot(final Token<?> lookhead) {
+  public void onBitNot(final Token<?> lookahead) {
     emit(OperatorIR.BIT_NOT);
   }
 
   @Override
-  public void onAdd(final Token<?> lookhead) {
+  public void onAdd(final Token<?> lookahead) {
     emit(OperatorIR.ADD);
   }
 
   @Override
-  public void onSub(final Token<?> lookhead) {
+  public void onSub(final Token<?> lookahead) {
     emit(OperatorIR.SUB);
 
   }
 
   @Override
-  public void onMult(final Token<?> lookhead) {
+  public void onMult(final Token<?> lookahead) {
     emit(OperatorIR.MULT);
   }
 
@@ -194,19 +194,19 @@ public class InterpretCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onDiv(final Token<?> lookhead) {
+  public void onDiv(final Token<?> lookahead) {
     emit(OperatorIR.DIV);
 
   }
 
   @Override
-  public void onAndLeft(final Token<?> lookhead) {
+  public void onAndLeft(final Token<?> lookahead) {
     if (!OperationRuntime.containsOpFunction(this.compileEnv, OperatorType.AND)) {
       emit(new AssertTypeIR(AssertTypes.Bool));
       Label label = makeLabel();
       pushLabel0(label);
       this.instruments
-          .add(new BranchUnlessIR(label, new SourceInfo(this.sourceFile, lookhead.getLineNo())));
+          .add(new BranchUnlessIR(label, new SourceInfo(this.sourceFile, lookahead.getLineNo())));
       emit(PopIR.INSTANCE);
     }
   }
@@ -226,7 +226,7 @@ public class InterpretCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onAndRight(final Token<?> lookhead) {
+  public void onAndRight(final Token<?> alookahead) {
     if (!OperationRuntime.containsOpFunction(this.compileEnv, OperatorType.AND)) {
       emit(new AssertTypeIR(AssertTypes.Bool));
       Label label = popLabel0();
@@ -237,20 +237,20 @@ public class InterpretCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onTernaryBoolean(final Token<?> lookhead) {
+  public void onTernaryBoolean(final Token<?> lookahead) {
     Label label0 = makeLabel();
     pushLabel0(label0);
     Label label1 = makeLabel();
     pushLabel1(label1);
     this.instruments
-        .add(new BranchUnlessIR(label0, new SourceInfo(this.sourceFile, lookhead.getLineNo())));
+        .add(new BranchUnlessIR(label0, new SourceInfo(this.sourceFile, lookahead.getLineNo())));
     emit(PopIR.INSTANCE);
   }
 
   @Override
-  public void onTernaryLeft(final Token<?> lookhead) {
+  public void onTernaryLeft(final Token<?> lookahead) {
     this.instruments
-        .add(new GotoIR(peekLabel1(), new SourceInfo(this.sourceFile, lookhead.getLineNo())));
+        .add(new GotoIR(peekLabel1(), new SourceInfo(this.sourceFile, lookahead.getLineNo())));
 
     // emit(PopIR.INSTANCE);
     Label label0 = popLabel0();
@@ -259,30 +259,30 @@ public class InterpretCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onTernaryRight(final Token<?> lookhead) {
+  public void onTernaryRight(final Token<?> lookahead) {
     Label label1 = popLabel1();
     visitLabel(label1);
   }
 
   @Override
-  public void onTernaryEnd(final Token<?> lookhead) {
+  public void onTernaryEnd(final Token<?> lookahead) {
     emit(ClearIR.INSTANCE);
   }
 
   @Override
-  public void onJoinLeft(final Token<?> lookhead) {
+  public void onJoinLeft(final Token<?> lookahead) {
     if (!OperationRuntime.containsOpFunction(this.compileEnv, OperatorType.AND)) {
       emit(new AssertTypeIR(AssertTypes.Bool));
       Label label = makeLabel();
       pushLabel0(label);
       this.instruments
-          .add(new BranchIfIR(label, new SourceInfo(this.sourceFile, lookhead.getLineNo())));
+          .add(new BranchIfIR(label, new SourceInfo(this.sourceFile, lookahead.getLineNo())));
       emit(PopIR.INSTANCE);
     }
   }
 
   @Override
-  public void onJoinRight(final Token<?> lookhead) {
+  public void onJoinRight(final Token<?> lookahead) {
     if (!OperationRuntime.containsOpFunction(this.compileEnv, OperatorType.AND)) {
       emit(new AssertTypeIR(AssertTypes.Bool));
       Label label = popLabel0();
@@ -293,52 +293,52 @@ public class InterpretCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onEq(final Token<?> lookhead) {
+  public void onEq(final Token<?> lookahead) {
     emit(OperatorIR.EQ);
   }
 
   @Override
-  public void onMatch(final Token<?> lookhead) {
+  public void onMatch(final Token<?> lookahead) {
     emit(OperatorIR.MATCH);
   }
 
   @Override
-  public void onNeq(final Token<?> lookhead) {
+  public void onNeq(final Token<?> lookahead) {
     emit(OperatorIR.NE);
   }
 
   @Override
-  public void onLt(final Token<?> lookhead) {
+  public void onLt(final Token<?> lookahead) {
     emit(OperatorIR.LT);
   }
 
   @Override
-  public void onLe(final Token<?> lookhead) {
+  public void onLe(final Token<?> lookahead) {
     emit(OperatorIR.LE);
   }
 
   @Override
-  public void onGt(final Token<?> lookhead) {
+  public void onGt(final Token<?> lookahead) {
     emit(OperatorIR.GT);
   }
 
   @Override
-  public void onGe(final Token<?> lookhead) {
+  public void onGe(final Token<?> lookahead) {
     emit(OperatorIR.GE);
   }
 
   @Override
-  public void onMod(final Token<?> lookhead) {
+  public void onMod(final Token<?> lookahead) {
     emit(OperatorIR.MOD);
   }
 
   @Override
-  public void onNot(final Token<?> lookhead) {
+  public void onNot(final Token<?> lookahead) {
     emit(OperatorIR.NOT);
   }
 
   @Override
-  public void onNeg(final Token<?> lookhead) {
+  public void onNeg(final Token<?> lookahead) {
     emit(OperatorIR.NEG);
   }
 
@@ -401,38 +401,38 @@ public class InterpretCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onConstant(final Token<?> lookhead) {
-    if (LOAD_CONSTANTS_TYPE.contains(lookhead.getType())) {
+  public void onConstant(final Token<?> lookahead) {
+    if (LOAD_CONSTANTS_TYPE.contains(lookahead.getType())) {
       VariableMeta meta = null;
 
-      if (lookhead.getType() == TokenType.Variable) {
-        meta = this.variables.get(lookhead.getLexeme());
+      if (lookahead.getType() == TokenType.Variable) {
+        meta = this.variables.get(lookahead.getLexeme());
       }
 
-      emit(new LoadIR(this.sourceFile, lookhead, meta, this.constantPool.contains(lookhead)));
+      emit(new LoadIR(this.sourceFile, lookahead, meta, this.constantPool.contains(lookahead)));
     }
   }
 
   @Override
-  public void onMethodName(final Token<?> lookhead) {
-    final MethodMetaData metadata = new MethodMetaData(lookhead,
-        lookhead.getType() == TokenType.Delegate ? null : lookhead.getLexeme());
+  public void onMethodName(final Token<?> lookahead) {
+    final MethodMetaData metadata = new MethodMetaData(lookahead,
+        lookahead.getType() == TokenType.Delegate ? null : lookahead.getLexeme());
     this.methodMetaDataStack.push(metadata);
   }
 
   @Override
-  public void onMethodParameter(final Token<?> lookhead) {
+  public void onMethodParameter(final Token<?> lookahead) {
     MethodMetaData currentMethodMetaData = this.methodMetaDataStack.peek();
     currentMethodMetaData.parameterCount++;
   }
 
   @Override
-  public void onMethodInvoke(final Token<?> lookhead) {
+  public void onMethodInvoke(final Token<?> lookahead) {
 
     final MethodMetaData methodMetaData = this.methodMetaDataStack.pop();
     @SuppressWarnings("unchecked")
-    final List<FunctionArgument> params = lookhead != null
-        ? (List<FunctionArgument>) lookhead.getMeta(Constants.PARAMS_META, Collections.EMPTY_LIST)
+    final List<FunctionArgument> params = lookahead != null
+        ? (List<FunctionArgument>) lookahead.getMeta(Constants.PARAMS_META, Collections.EMPTY_LIST)
         : Collections.<FunctionArgument>emptyList();
 
     if (this.instance.getOptionValue(Options.CAPTURE_FUNCTION_ARGS).bool) {
@@ -447,10 +447,10 @@ public class InterpretCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onLambdaDefineStart(final Token<?> lookhead) {
+  public void onLambdaDefineStart(final Token<?> lookahead) {
     if (this.lambdaGenerator == null) {
-      Boolean newLexicalScope = lookhead.getMeta(Constants.SCOPE_META, false);
-      Boolean inheritEnv = lookhead.getMeta(Constants.INHERIT_ENV_META, false);
+      Boolean newLexicalScope = lookahead.getMeta(Constants.SCOPE_META, false);
+      Boolean inheritEnv = lookahead.getMeta(Constants.INHERIT_ENV_META, false);
       // TODO cache?
       this.lambdaGenerator = new LambdaGenerator(this.instance, this, this.parser, this.classLoader,
           this.sourceFile, newLexicalScope, inheritEnv);
@@ -462,18 +462,18 @@ public class InterpretCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onLambdaArgument(final Token<?> lookhead, final FunctionParam param) {
+  public void onLambdaArgument(final Token<?> lookahead, final FunctionParam param) {
     this.lambdaGenerator.addParam(param);
   }
 
   @Override
-  public void onLambdaBodyStart(final Token<?> lookhead) {
+  public void onLambdaBodyStart(final Token<?> lookahead) {
     this.parentCodeGenerator = this.parser.getCodeGenerator();
     this.parser.setCodeGenerator(this.lambdaGenerator);
   }
 
   @Override
-  public void onLambdaBodyEnd(final Token<?> lookhead) {
+  public void onLambdaBodyEnd(final Token<?> lookahead) {
     // this.lambdaGenerator.compileCallMethod();
     LambdaFunctionBootstrap bootstrap = this.lambdaGenerator.getLmabdaBootstrap();
     if (this.lambdaBootstraps == null) {
@@ -488,15 +488,15 @@ public class InterpretCodeGenerator extends BaseEvalCodeGenerator {
   }
 
   @Override
-  public void onArray(final Token<?> lookhead) {
-    onConstant(lookhead);
+  public void onArray(final Token<?> lookahead) {
+    onConstant(lookahead);
   }
 
   @Override
   public void onArrayIndexStart(final Token<?> token) {}
 
   @Override
-  public void onArrayIndexEnd(final Token<?> lookhead) {
+  public void onArrayIndexEnd(final Token<?> lookahead) {
     emit(OperatorIR.INDEX);
   }
 

--- a/src/main/java/com/googlecode/aviator/lexer/token/OperatorToken.java
+++ b/src/main/java/com/googlecode/aviator/lexer/token/OperatorToken.java
@@ -35,10 +35,10 @@ public class OperatorToken extends AbstractToken<OperatorType> {
   }
 
 
-  public OperatorToken(final Token<?> lookhead, final OperatorType operatorType) {
-    super(operatorType.getToken(), lookhead != null ? lookhead.getLineNo() : 0,
-        lookhead != null ? lookhead.getStartIndex() : -1);
-    setMetaMap(lookhead != null ? lookhead.getMetaMap() : null);
+  public OperatorToken(final Token<?> lookahead, final OperatorType operatorType) {
+    super(operatorType.getToken(), lookahead != null ? lookahead.getLineNo() : 0,
+        lookahead != null ? lookahead.getStartIndex() : -1);
+    setMetaMap(lookahead != null ? lookahead.getMetaMap() : null);
     this.operatorType = operatorType;
   }
 

--- a/src/test/java/com/googlecode/aviator/parser/FakeCodeGenerator.java
+++ b/src/test/java/com/googlecode/aviator/parser/FakeCodeGenerator.java
@@ -64,13 +64,13 @@ public class FakeCodeGenerator implements CodeGenerator {
 
 
   @Override
-  public void onAdd(final Token<?> lookhead) {
+  public void onAdd(final Token<?> lookahead) {
     appendToken("+");
   }
 
 
   @Override
-  public void onTernaryEnd(final Token<?> lookhead) {
+  public void onTernaryEnd(final Token<?> lookahead) {
     appendToken(";");
 
   }
@@ -85,179 +85,179 @@ public class FakeCodeGenerator implements CodeGenerator {
   }
 
   @Override
-  public void onAndLeft(final Token<?> lookhead) {
+  public void onAndLeft(final Token<?> lookahead) {
 
   }
 
 
   @Override
-  public void onAndRight(final Token<?> lookhead) {
+  public void onAndRight(final Token<?> alookahead) {
     appendToken("&&");
 
   }
 
 
   @Override
-  public void onJoinRight(final Token<?> lookhead) {
+  public void onJoinRight(final Token<?> lookahead) {
     appendToken("||");
   }
 
 
   @Override
-  public void onTernaryBoolean(final Token<?> lookhead) {
+  public void onTernaryBoolean(final Token<?> lookahead) {
 
   }
 
 
   @Override
-  public void onTernaryLeft(final Token<?> lookhead) {
+  public void onTernaryLeft(final Token<?> lookahead) {
 
   }
 
 
   @Override
-  public void onTernaryRight(final Token<?> lookhead) {
+  public void onTernaryRight(final Token<?> lookahead) {
     appendToken("?:");
   }
 
 
   @Override
-  public void onConstant(final Token<?> lookhead) {
-    appendToken(lookhead.getLexeme());
+  public void onConstant(final Token<?> lookahead) {
+    appendToken(lookahead.getLexeme());
   }
 
 
   @Override
-  public void onDiv(final Token<?> lookhead) {
+  public void onDiv(final Token<?> lookahead) {
     appendToken("/");
 
   }
 
 
   @Override
-  public void onEq(final Token<?> lookhead) {
+  public void onEq(final Token<?> lookahead) {
     appendToken("==");
 
   }
 
 
   @Override
-  public void onAssignment(final Token<?> lookhead) {
+  public void onAssignment(final Token<?> lookahead) {
     appendToken("=");
   }
 
 
   @Override
-  public void onGe(final Token<?> lookhead) {
+  public void onGe(final Token<?> lookahead) {
     appendToken(">=");
 
   }
 
 
   @Override
-  public void onGt(final Token<?> lookhead) {
+  public void onGt(final Token<?> lookahead) {
     appendToken(">");
 
   }
 
 
   @Override
-  public void onJoinLeft(final Token<?> lookhead) {
+  public void onJoinLeft(final Token<?> lookahead) {
 
   }
 
 
   @Override
-  public void onLe(final Token<?> lookhead) {
+  public void onLe(final Token<?> lookahead) {
     appendToken("<=");
 
   }
 
 
   @Override
-  public void onLt(final Token<?> lookhead) {
+  public void onLt(final Token<?> lookahead) {
     appendToken("<");
 
   }
 
 
   @Override
-  public void onMatch(final Token<?> lookhead) {
+  public void onMatch(final Token<?> lookahead) {
     appendToken("=~");
 
   }
 
 
   @Override
-  public void onMod(final Token<?> lookhead) {
+  public void onMod(final Token<?> lookahead) {
     appendToken("%");
 
   }
 
 
   @Override
-  public void onMult(final Token<?> lookhead) {
+  public void onMult(final Token<?> lookahead) {
     appendToken("*");
 
   }
 
 
   @Override
-  public void onExponent(final Token<?> lookhead) {
+  public void onExponent(final Token<?> lookahead) {
     appendToken("**");
   }
 
 
   @Override
-  public void onNeg(final Token<?> lookhead) {
+  public void onNeg(final Token<?> lookahead) {
     appendToken("-");
 
   }
 
 
   @Override
-  public void onNeq(final Token<?> lookhead) {
+  public void onNeq(final Token<?> lookahead) {
     appendToken("!=");
 
   }
 
 
   @Override
-  public void onNot(final Token<?> lookhead) {
+  public void onNot(final Token<?> lookahead) {
     appendToken("!");
 
   }
 
 
   @Override
-  public void onSub(final Token<?> lookhead) {
+  public void onSub(final Token<?> lookahead) {
     appendToken("-");
   }
 
 
   @Override
-  public void onMethodInvoke(final Token<?> lookhead) {
-    final List<FunctionArgument> params = lookhead.getMeta(Constants.PARAMS_META, null);
+  public void onMethodInvoke(final Token<?> lookahead) {
+    final List<FunctionArgument> params = lookahead.getMeta(Constants.PARAMS_META, null);
     appendToken("method_invoke<" + (params == null ? "" : params.toString()) + ">");
 
   }
 
 
   @Override
-  public void onMethodName(final Token<?> lookhead) {
+  public void onMethodName(final Token<?> lookahead) {
 
   }
 
 
   @Override
-  public void onMethodParameter(final Token<?> lookhead) {
+  public void onMethodParameter(final Token<?> lookahead) {
 
   }
 
 
   @Override
-  public void onArray(final Token<?> lookhead) {
-    appendToken(lookhead.getLexeme());
+  public void onArray(final Token<?> lookahead) {
+    appendToken(lookahead.getLexeme());
   }
 
 
@@ -268,78 +268,78 @@ public class FakeCodeGenerator implements CodeGenerator {
 
 
   @Override
-  public void onArrayIndexEnd(final Token<?> lookhead) {
+  public void onArrayIndexEnd(final Token<?> lookahead) {
     appendToken("[]");
 
   }
 
 
   @Override
-  public void onBitAnd(final Token<?> lookhead) {
+  public void onBitAnd(final Token<?> lookahead) {
     appendToken("&");
 
   }
 
 
   @Override
-  public void onBitNot(final Token<?> lookhead) {
+  public void onBitNot(final Token<?> lookahead) {
     appendToken("~");
 
   }
 
 
   @Override
-  public void onBitOr(final Token<?> lookhead) {
+  public void onBitOr(final Token<?> lookahead) {
     appendToken("|");
 
   }
 
 
   @Override
-  public void onBitXor(final Token<?> lookhead) {
+  public void onBitXor(final Token<?> lookahead) {
     appendToken("^");
 
   }
 
 
   @Override
-  public void onShiftLeft(final Token<?> lookhead) {
+  public void onShiftLeft(final Token<?> lookahead) {
     appendToken("<<");
 
   }
 
   @Override
-  public void onLambdaDefineStart(final Token<?> lookhead) {
-    this.scopes.push(this.parser.enterScope(lookhead.getMeta(Constants.SCOPE_META, false)));
+  public void onLambdaDefineStart(final Token<?> lookahead) {
+    this.scopes.push(this.parser.enterScope(lookahead.getMeta(Constants.SCOPE_META, false)));
   }
 
 
   @Override
-  public void onLambdaBodyStart(final Token<?> lookhead) {
+  public void onLambdaBodyStart(final Token<?> lookahead) {
 
   }
 
 
   @Override
-  public void onLambdaArgument(final Token<?> lookhead, final FunctionParam param) {}
+  public void onLambdaArgument(final Token<?> lookahead, final FunctionParam param) {}
 
 
   @Override
-  public void onLambdaBodyEnd(final Token<?> lookhead) {
+  public void onLambdaBodyEnd(final Token<?> lookahead) {
     appendToken("lambda<defined>");
     this.parser.restoreScope(this.scopes.pop());
   }
 
 
   @Override
-  public void onShiftRight(final Token<?> lookhead) {
+  public void onShiftRight(final Token<?> lookahead) {
     appendToken(">>");
 
   }
 
 
   @Override
-  public void onUnsignedShiftRight(final Token<?> lookhead) {
+  public void onUnsignedShiftRight(final Token<?> lookahead) {
     appendToken(">>>");
 
   }


### PR DESCRIPTION
## Summary

This pull request corrects the consistent typo 'lookhead' to 'lookahead' across multiple files in the codebase, improving readability and maintaining consistent terminology to prevent potential confusion for future developers.

## Impact

This change does not alter the functionality of the code but improves readability and consistency, making it easier for developers to understand and maintain the codebase.

## Testing

All existing tests have been run to ensure no functionality is broken due to these changes. No new tests were required as this is a non-functional change.

If there are any additional areas that need review or specific scenarios to test, please let me know. Thank you for reviewing this PR.
