### PR TITLE
compileScript 支持传入 InputStream 

### DIFF
--- a/src/main/java/com/googlecode/aviator/AviatorEvaluatorInstance.java
+++ b/src/main/java/com/googlecode/aviator/AviatorEvaluatorInstance.java
@@ -556,6 +556,41 @@ public final class AviatorEvaluatorInstance {
   }
 
   /**
+   * Compile a script into expression.
+   *
+   * @param cacheKey caching key when cached is true.
+   * @param in       the script file's InputStream
+   * @param name     source file name
+   * @return the compiled expression instance.
+   * @throws IOException
+   * @since 5.0.0
+   */
+  public Expression compileScript(final String cacheKey, final InputStream in,
+                                  final String name)
+          throws IOException {
+    return this.compileScript(cacheKey, in, name, this.cachedExpressionByDefault);
+  }
+
+  /**
+   * Compile a script into expression.
+   *
+   * @param cacheKey caching key when cached is true.
+   * @param in       the script file's InputStream
+   * @param name     source file name
+   * @param cached   whether to cache the expression instance by cacheKey.
+   * @return the compiled expression instance.
+   * @throws IOException
+   * @since 5.0.0
+   */
+  public Expression compileScript(final String cacheKey, final InputStream in,
+                                  final String name, final boolean cached)
+          throws IOException {
+    Reader reader = new InputStreamReader(in, Charset.forName("utf-8"));
+    return compile(cacheKey, Utils.readFully(reader), name, cached);
+  }
+
+
+  /**
    * Returns the function missing handler, null if not set.
    *
    * @since 4.2.5


### PR DESCRIPTION
当前 compile Script 只支持传入文件 path，当策略文件封装进 jar 包时，java 无法获取 file 对象及 path，期望能支持 InputStream 的 compile Script